### PR TITLE
Добавлена афиша Intickets и серверная прокси

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# URL Intickets с JSON-фидом событий
+INTICKETS_EVENTS_URL=https://example.intickets.ru/api/v1/events
+
+# Токен доступа (если требуется)
+# Можно использовать тестовый ключ: b38b5af4-a37b-2a49-66e7-30631ea777e5
+INTICKETS_TOKEN=

--- a/README.md
+++ b/README.md
@@ -1,1 +1,68 @@
-# new
+# AmmA Production — лендинг и афиша
+
+Одностраничный сайт продюсерского центра AmmA Production со встроенным виджетом афиши, который получает события из API Intickets через серверную функцию.
+
+## Структура проекта
+
+- `index.html` — главная страница с краткой информацией, слайдером и блоком предпросмотра ближайших событий.
+- `afisha.html` — полноценная страница афиши с сеткой мероприятий.
+- `afisha.css` — стили для страницы афиши.
+- `afisha.js` — клиентский виджет, который подгружает события Intickets и наполняет карточки.
+- `api/intickets-events.js` — серверная функция (Vercel/Netlify), проксирующая запросы к Intickets и скрывающая токен.
+
+## Настройка переменных окружения
+
+Перед деплоем нужно задать переменные:
+
+| Переменная | Описание |
+|------------|----------|
+| `INTICKETS_EVENTS_URL` | Полный URL JSON-фида c событиями (предоставляется Intickets в личном кабинете). |
+| `INTICKETS_TOKEN` | Токен доступа, если фид защищён. Для тестирования можно использовать ключ `b38b5af4-a37b-2a49-66e7-30631ea777e5`. |
+
+Пример `.env` файла:
+
+```env
+INTICKETS_EVENTS_URL=https://example.intickets.ru/api/v1/events
+INTICKETS_TOKEN=b38b5af4-a37b-2a49-66e7-30631ea777e5
+```
+
+> Не храните рабочий ключ в репозитории. Добавьте переменные окружения в настройках хостинга (Vercel/Netlify/Render и т. п.).
+
+## Локальный запуск
+
+1. Создайте `.env` файл с переменными окружения.
+2. Запустите любой статический сервер (например, `npx serve .` или `python3 -m http.server`).
+3. Для работы прокси `/api/intickets-events` нужен средний слой (Vercel dev, Netlify dev, Node/Express). Проще всего использовать Vercel CLI:
+
+   ```bash
+   npm i -g vercel
+   vercel dev
+   ```
+
+   или Netlify CLI:
+
+   ```bash
+   npm i -g netlify-cli
+   netlify dev
+   ```
+
+4. Откройте `http://localhost:3000` (или адрес, выданный CLI).
+
+## Деплой
+
+- **Vercel**: положите проект в репозиторий, подключите его в Vercel, задайте переменные окружения и задеплойте. Файл `api/intickets-events.js` автоматически станет serverless-функцией.
+- **Netlify**: аналогично; функция будет доступна как `/.netlify/functions/intickets-events`.
+- **Собственный Node**: подключите файл из `api/intickets-events.js` в свой Express/Koa сервер или создайте отдельный endpoint с такой же логикой.
+
+## Пользовательский виджет афиши
+
+Чтобы встроить сетку афиши на любую страницу, добавьте контейнер с атрибутом `data-afisha-root` и подключите `afisha.js`:
+
+```html
+<section data-afisha-root data-afisha-limit="3">
+    <div data-afisha-grid>Загрузка…</div>
+</section>
+<script src="afisha.js" defer></script>
+```
+
+По умолчанию скрипт обращается к `/api/intickets-events`. Можно переопределить URL через атрибут `data-afisha-endpoint`.

--- a/afisha.css
+++ b/afisha.css
@@ -1,0 +1,337 @@
+:root {
+    color-scheme: dark;
+    --afisha-bg: #0b0d10;
+    --afisha-surface: rgba(20, 24, 30, 0.85);
+    --afisha-accent: #f6c945;
+    --afisha-text: #f7f7f7;
+    --afisha-muted: rgba(247, 247, 247, 0.7);
+    --afisha-border: rgba(246, 201, 69, 0.12);
+    --afisha-radius: 18px;
+    --afisha-spacing: clamp(1rem, 2.5vw, 2rem);
+    --afisha-grid-gap: clamp(1.25rem, 3vw, 2.5rem);
+    font-family: 'Manrope', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(246, 201, 69, 0.12), transparent 55%),
+        radial-gradient(circle at 80% 0%, rgba(246, 201, 69, 0.08), transparent 45%),
+        var(--afisha-bg);
+    color: var(--afisha-text);
+    min-height: 100vh;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+    color: var(--afisha-accent);
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+}
+
+.afisha-header {
+    padding: 1.5rem clamp(1rem, 5vw, 3.5rem) 0;
+}
+
+.afisha-header__inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.afisha-brand {
+    font-family: 'Cinzel', serif;
+    font-size: clamp(1.6rem, 4vw, 2.4rem);
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+}
+
+.afisha-nav {
+    display: flex;
+    gap: 1.25rem;
+    align-items: center;
+}
+
+.afisha-nav__link {
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--afisha-muted);
+    position: relative;
+    padding-bottom: 0.35rem;
+}
+
+.afisha-nav__link::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background: var(--afisha-accent);
+    transform: scaleX(0);
+    transform-origin: right;
+    transition: transform 0.3s ease;
+}
+
+.afisha-nav__link:hover::after,
+.afisha-nav__link[aria-current="page"]::after {
+    transform: scaleX(1);
+    transform-origin: left;
+}
+
+.afisha-main {
+    flex: 1 0 auto;
+    width: min(1120px, 100%);
+    margin: 0 auto;
+    padding: clamp(2rem, 4vw, 4rem) clamp(1.25rem, 5vw, 3rem) 5rem;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(2.5rem, 5vw, 4rem);
+}
+
+.afisha-intro {
+    display: grid;
+    gap: 1.5rem;
+    text-align: center;
+    justify-items: center;
+}
+
+.afisha-intro__heading {
+    font-family: 'Cinzel', serif;
+    font-weight: 400;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-size: clamp(1.8rem, 5vw, 2.8rem);
+    margin: 0;
+}
+
+.afisha-intro__description {
+    margin: 0;
+    max-width: 48ch;
+    color: var(--afisha-muted);
+    font-size: 1.05rem;
+    line-height: 1.6;
+}
+
+.afisha-controls {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.afisha-control-button {
+    background: transparent;
+    border: 1px solid var(--afisha-border);
+    border-radius: 999px;
+    color: var(--afisha-muted);
+    padding: 0.65rem 1.5rem;
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: border-color 0.3s ease, color 0.3s ease, background 0.3s ease;
+}
+
+.afisha-control-button:hover,
+.afisha-control-button:focus-visible,
+.afisha-control-button[aria-pressed="true"] {
+    border-color: var(--afisha-accent);
+    color: var(--afisha-text);
+    background: rgba(246, 201, 69, 0.08);
+}
+
+.afisha-grid-section {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.afisha-grid-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.afisha-grid-title {
+    margin: 0;
+    font-size: clamp(1.4rem, 3.5vw, 2rem);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-family: 'Cinzel', serif;
+}
+
+.afisha-grid-action {
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--afisha-accent);
+}
+
+.afisha-grid {
+    display: grid;
+    gap: var(--afisha-grid-gap);
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+
+.afisha-card {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    gap: 1rem;
+    background: var(--afisha-surface);
+    border: 1px solid var(--afisha-border);
+    border-radius: var(--afisha-radius);
+    padding: 1.25rem;
+    backdrop-filter: blur(12px);
+    box-shadow: 0 24px 60px rgba(5, 7, 10, 0.35);
+    transition: transform 0.4s ease, border-color 0.4s ease;
+}
+
+.afisha-card:hover,
+.afisha-card:focus-within {
+    transform: translateY(-6px);
+    border-color: rgba(246, 201, 69, 0.4);
+}
+
+.afisha-card__poster {
+    position: relative;
+    overflow: hidden;
+    border-radius: calc(var(--afisha-radius) * 0.8);
+    aspect-ratio: 3 / 4;
+    background: linear-gradient(135deg, rgba(246, 201, 69, 0.15), transparent 65%);
+}
+
+.afisha-card__poster img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    filter: saturate(1.05);
+}
+
+.afisha-card__body {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.afisha-card__title {
+    margin: 0;
+    font-size: 1.1rem;
+    line-height: 1.4;
+}
+
+.afisha-card__meta {
+    display: grid;
+    gap: 0.35rem;
+    font-size: 0.95rem;
+    color: var(--afisha-muted);
+}
+
+.afisha-card__meta-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.afisha-card__meta-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(247, 247, 247, 0.55);
+}
+
+.afisha-card__description {
+    margin: 0;
+    color: rgba(247, 247, 247, 0.8);
+    font-size: 0.95rem;
+    line-height: 1.55;
+}
+
+.afisha-card__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.afisha-card__price {
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--afisha-accent);
+}
+
+.afisha-card__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    border: 1px solid rgba(246, 201, 69, 0.25);
+    color: var(--afisha-text);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+.afisha-card__link::after {
+    content: '→';
+    font-size: 1.1rem;
+}
+
+.afisha-card__link:hover,
+.afisha-card__link:focus-visible {
+    background: rgba(246, 201, 69, 0.15);
+    border-color: var(--afisha-accent);
+}
+
+.afisha-status {
+    margin: 0;
+    padding: 2rem;
+    text-align: center;
+    background: rgba(20, 24, 30, 0.7);
+    border-radius: var(--afisha-radius);
+    border: 1px dashed rgba(246, 201, 69, 0.3);
+    color: var(--afisha-muted);
+}
+
+.afisha-footer {
+    padding: 2rem clamp(1.25rem, 5vw, 3rem) 3rem;
+    text-align: center;
+    color: rgba(247, 247, 247, 0.6);
+    font-size: 0.9rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+@media (max-width: 640px) {
+    .afisha-nav {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .afisha-header__inner {
+        justify-content: center;
+    }
+
+    .afisha-card {
+        padding: 1rem;
+    }
+}

--- a/afisha.html
+++ b/afisha.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Афиша AmmA Production</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;700&family=Manrope:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="afisha.css">
+</head>
+<body>
+    <header class="afisha-header">
+        <div class="afisha-header__inner">
+            <a class="afisha-brand" href="index.html">AmmA Production</a>
+            <nav class="afisha-nav" aria-label="Основная навигация">
+                <a class="afisha-nav__link" href="index.html">Главная</a>
+                <a class="afisha-nav__link" href="afisha.html" aria-current="page">Афиша</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="afisha-main">
+        <section class="afisha-intro">
+            <h1 class="afisha-intro__heading">Афиша AmmA Production</h1>
+            <p class="afisha-intro__description">
+                Следите за свежими постановками и гастролями. Мы подгружаем список событий напрямую из Intickets,
+                поэтому здесь всегда актуальная информация и возможность перейти к покупке билетов.
+            </p>
+        </section>
+
+        <section class="afisha-grid-section" data-afisha-root data-afisha-limit="12">
+            <div class="afisha-grid-header">
+                <h2 class="afisha-grid-title">Ближайшие события</h2>
+                <a class="afisha-grid-action" href="https://intickets.ru/" target="_blank" rel="noopener">Все события</a>
+            </div>
+            <div class="afisha-grid" data-afisha-grid>
+                <p class="afisha-status">Загружаем события…</p>
+            </div>
+        </section>
+    </main>
+
+    <footer class="afisha-footer">
+        © 2024 AmmA Production. Все права защищены.
+    </footer>
+
+    <script src="afisha.js" defer></script>
+</body>
+</html>

--- a/afisha.js
+++ b/afisha.js
@@ -1,0 +1,407 @@
+(function () {
+    const DEFAULT_ENDPOINT = '/api/intickets-events';
+    const DATE_FORMATTER = new Intl.DateTimeFormat('ru-RU', {
+        weekday: 'long',
+        day: 'numeric',
+        month: 'long',
+    });
+    const DATE_TIME_FORMATTER = new Intl.DateTimeFormat('ru-RU', {
+        day: 'numeric',
+        month: 'long',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+    const TIME_FORMATTER = new Intl.DateTimeFormat('ru-RU', {
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+
+    function extractValue(source, path) {
+        if (!source || !path) {
+            return undefined;
+        }
+
+        const segments = Array.isArray(path) ? path : String(path).split('.');
+        let current = source;
+
+        for (const rawSegment of segments) {
+            if (current == null) {
+                return undefined;
+            }
+
+            const segment = rawSegment.trim();
+            const numericIndex = Number(segment);
+
+            if (Array.isArray(current) && !Number.isNaN(numericIndex)) {
+                current = current[numericIndex];
+            } else {
+                current = current[segment];
+            }
+        }
+
+        return current;
+    }
+
+    function pickFirst(source, keys) {
+        if (!Array.isArray(keys)) {
+            return undefined;
+        }
+
+        for (const key of keys) {
+            const value = extractValue(source, key);
+            if (value != null && value !== '') {
+                return value;
+            }
+        }
+
+        return undefined;
+    }
+
+    function normaliseEvents(payload) {
+        if (!payload) {
+            return [];
+        }
+
+        if (Array.isArray(payload)) {
+            return payload;
+        }
+
+        const preferredKeys = ['events', 'data', 'items', 'results', 'list'];
+        for (const key of preferredKeys) {
+            if (Array.isArray(payload[key])) {
+                return payload[key];
+            }
+        }
+
+        if (Array.isArray(payload.records)) {
+            return payload.records;
+        }
+
+        return [];
+    }
+
+    function toDate(value) {
+        if (!value) {
+            return null;
+        }
+
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) {
+            return null;
+        }
+
+        return parsed;
+    }
+
+    function formatDateTime(value) {
+        const date = toDate(value);
+        if (!date) {
+            return null;
+        }
+
+        return {
+            label: DATE_TIME_FORMATTER.format(date),
+            dateLabel: DATE_FORMATTER.format(date),
+            timeLabel: TIME_FORMATTER.format(date),
+            date,
+        };
+    }
+
+    function normaliseEvent(raw) {
+        const title = pickFirst(raw, ['title', 'name', 'event_title', 'eventName', 'label']) || 'Без названия';
+        const description = pickFirst(raw, [
+            'short_description',
+            'shortDescription',
+            'preview',
+            'teaser',
+            'excerpt',
+            'description',
+        ]);
+        const url = pickFirst(raw, ['url', 'link', 'event_url', 'purchase_url', 'web_url', 'site_url']);
+        const startRaw = pickFirst(raw, [
+            'start',
+            'start_at',
+            'startAt',
+            'datetime_start',
+            'date',
+            'date_start',
+            'date_from',
+            'first_event_date',
+            'sessions.0.start_at',
+        ]);
+        const endRaw = pickFirst(raw, [
+            'end',
+            'end_at',
+            'datetime_end',
+            'date_end',
+            'date_to',
+        ]);
+        const venue = pickFirst(raw, [
+            'venue.title',
+            'venue.name',
+            'location.title',
+            'location.name',
+            'city',
+            'place',
+        ]);
+        const city = pickFirst(raw, ['venue.city', 'location.city', 'city']);
+        const currency = pickFirst(raw, ['currency', 'price.currency', 'prices.currency']) || '₽';
+        const minPrice = pickFirst(raw, [
+            'price_min',
+            'min_price',
+            'price.from',
+            'prices.from',
+            'price_minimum',
+        ]);
+        const maxPrice = pickFirst(raw, [
+            'price_max',
+            'max_price',
+            'price.to',
+            'prices.to',
+            'price_maximum',
+        ]);
+        const image = pickFirst(raw, [
+            'poster',
+            'poster.url',
+            'poster.small',
+            'cover',
+            'cover.url',
+            'image',
+            'image.url',
+            'images.0',
+            'media.poster.url',
+        ]);
+
+        return {
+            id: raw.id || raw.event_id || raw.slug || `${title}-${startRaw || Math.random()}`,
+            title,
+            description,
+            url,
+            start: formatDateTime(startRaw),
+            end: formatDateTime(endRaw),
+            venue,
+            city,
+            minPrice: typeof minPrice === 'number' ? minPrice : Number(minPrice),
+            maxPrice: typeof maxPrice === 'number' ? maxPrice : Number(maxPrice),
+            currency,
+            image: typeof image === 'string' ? image : (image && image.url) ? image.url : undefined,
+        };
+    }
+
+    function truncate(text, limit = 160) {
+        if (!text) {
+            return '';
+        }
+
+        const clean = String(text).replace(/<[^>]*>/g, '').trim();
+        if (clean.length <= limit) {
+            return clean;
+        }
+
+        return `${clean.slice(0, limit - 1).trim()}…`;
+    }
+
+    function formatPrice(min, max, currency) {
+        if (min == null && max == null) {
+            return null;
+        }
+
+        const formatter = new Intl.NumberFormat('ru-RU');
+        const resolvedCurrency = currency || '₽';
+
+        const safeMin = typeof min === 'number' && !Number.isNaN(min) ? min : null;
+        const safeMax = typeof max === 'number' && !Number.isNaN(max) ? max : null;
+
+        if (safeMin != null && safeMax != null) {
+            if (safeMin === safeMax) {
+                return `${formatter.format(safeMin)} ${resolvedCurrency}`;
+            }
+
+            return `${formatter.format(Math.min(safeMin, safeMax))}–${formatter.format(Math.max(safeMin, safeMax))} ${resolvedCurrency}`;
+        }
+
+        const single = safeMin ?? safeMax;
+        if (single == null) {
+            return null;
+        }
+
+        return `${formatter.format(single)} ${resolvedCurrency}`;
+    }
+
+    function createMetaRow(label, value) {
+        if (!value) {
+            return null;
+        }
+
+        const row = document.createElement('div');
+        row.className = 'afisha-card__meta-row';
+
+        const labelEl = document.createElement('span');
+        labelEl.className = 'afisha-card__meta-label';
+        labelEl.textContent = label;
+
+        const valueEl = document.createElement('span');
+        valueEl.textContent = value;
+
+        row.append(labelEl, valueEl);
+        return row;
+    }
+
+    function createEventCard(event) {
+        const article = document.createElement('article');
+        article.className = 'afisha-card';
+
+        if (event.image) {
+            const poster = document.createElement('div');
+            poster.className = 'afisha-card__poster';
+            const img = document.createElement('img');
+            img.src = event.image;
+            img.alt = `${event.title}: афиша`;
+            img.loading = 'lazy';
+            poster.appendChild(img);
+            article.appendChild(poster);
+        }
+
+        const body = document.createElement('div');
+        body.className = 'afisha-card__body';
+
+        const titleEl = document.createElement('h3');
+        titleEl.className = 'afisha-card__title';
+        titleEl.textContent = event.title;
+        body.appendChild(titleEl);
+
+        const meta = document.createElement('div');
+        meta.className = 'afisha-card__meta';
+
+        const dateRow = createMetaRow('Дата', event.start?.dateLabel || event.start?.label);
+        if (dateRow) {
+            meta.appendChild(dateRow);
+        }
+
+        const timeRow = createMetaRow('Время', event.start?.timeLabel);
+        if (timeRow) {
+            meta.appendChild(timeRow);
+        }
+
+        if (event.venue) {
+            const venueRow = createMetaRow('Площадка', event.city ? `${event.venue}, ${event.city}` : event.venue);
+            if (venueRow) {
+                meta.appendChild(venueRow);
+            }
+        }
+
+        if (meta.children.length > 0) {
+            body.appendChild(meta);
+        }
+
+        if (event.description) {
+            const descriptionEl = document.createElement('p');
+            descriptionEl.className = 'afisha-card__description';
+            descriptionEl.textContent = truncate(event.description);
+            body.appendChild(descriptionEl);
+        }
+
+        article.appendChild(body);
+
+        const footer = document.createElement('div');
+        footer.className = 'afisha-card__footer';
+
+        const priceLabel = formatPrice(event.minPrice, event.maxPrice, event.currency);
+        if (priceLabel) {
+            const priceEl = document.createElement('span');
+            priceEl.className = 'afisha-card__price';
+            priceEl.textContent = priceLabel;
+            footer.appendChild(priceEl);
+        }
+
+        if (event.url) {
+            const link = document.createElement('a');
+            link.className = 'afisha-card__link';
+            link.href = event.url;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            link.textContent = 'Купить билеты';
+            footer.appendChild(link);
+        }
+
+        if (footer.children.length > 0) {
+            article.appendChild(footer);
+        }
+
+        return article;
+    }
+
+    function showStatus(container, message) {
+        container.innerHTML = '';
+        const status = document.createElement('p');
+        status.className = 'afisha-status';
+        status.textContent = message;
+        container.appendChild(status);
+    }
+
+    async function loadWidget(root) {
+        if (!root || root.dataset.afishaMounted === 'true') {
+            return;
+        }
+
+        root.dataset.afishaMounted = 'true';
+        const grid = root.querySelector('[data-afisha-grid]') || root;
+        showStatus(grid, 'Загружаем события…');
+
+        const endpoint = root.dataset.afishaEndpoint || DEFAULT_ENDPOINT;
+        const params = new URLSearchParams();
+        const limit = root.dataset.afishaLimit;
+        if (limit) {
+            params.set('limit', limit);
+        }
+
+        const url = params.size > 0 ? `${endpoint}?${params.toString()}` : endpoint;
+
+        try {
+            const response = await fetch(url, {
+                headers: {
+                    Accept: 'application/json',
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(`Запрос завершился с кодом ${response.status}`);
+            }
+
+            const payload = await response.json();
+            const events = normaliseEvents(payload).map(normaliseEvent).filter(Boolean);
+
+            grid.innerHTML = '';
+
+            if (events.length === 0) {
+                showStatus(grid, 'Ближайших событий пока нет. Загляните позже.');
+                return;
+            }
+
+            events.forEach((event) => {
+                grid.appendChild(createEventCard(event));
+            });
+        } catch (error) {
+            console.error('Не удалось загрузить афишу Intickets', error);
+            showStatus(grid, 'Не удалось загрузить события. Попробуйте обновить страницу позже.');
+        }
+    }
+
+    function boot() {
+        const widgets = document.querySelectorAll('[data-afisha-root]');
+        widgets.forEach((widget) => {
+            loadWidget(widget);
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', boot);
+    } else {
+        boot();
+    }
+
+    window.AfishaWidget = Object.assign(window.AfishaWidget || {}, {
+        refresh: boot,
+        mount: loadWidget,
+    });
+})();

--- a/api/intickets-events.js
+++ b/api/intickets-events.js
@@ -1,0 +1,137 @@
+const ALLOWED_QUERY_PARAMS = new Set([
+    'limit',
+    'page',
+    'city',
+    'venue',
+    'category',
+    'date_from',
+    'date_to',
+    'project',
+    'search',
+    'sort',
+]);
+
+const DEFAULT_HEADERS = {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+};
+
+function buildJsonResponse(statusCode, payload, extraHeaders = {}) {
+    return {
+        statusCode,
+        headers: { ...DEFAULT_HEADERS, ...extraHeaders },
+        body: payload != null ? JSON.stringify(payload) : '',
+    };
+}
+
+async function fetchEvents(query = {}) {
+    const endpoint = process.env.INTICKETS_EVENTS_URL;
+
+    if (!endpoint) {
+        return buildJsonResponse(500, {
+            error: 'INTICKETS_EVENTS_URL is not configured. Set the environment variable before deploying.',
+        });
+    }
+
+    let requestUrl;
+    try {
+        requestUrl = new URL(endpoint);
+    } catch (error) {
+        return buildJsonResponse(500, {
+            error: 'Invalid INTICKETS_EVENTS_URL value.',
+            details: error.message,
+        });
+    }
+
+    Object.entries(query)
+        .filter(([key, value]) => ALLOWED_QUERY_PARAMS.has(key) && value != null && value !== '')
+        .forEach(([key, value]) => {
+            requestUrl.searchParams.set(key, value);
+        });
+
+    const headers = {
+        Accept: 'application/json',
+    };
+
+    const token = process.env.INTICKETS_TOKEN || process.env.INTICKETS_API_KEY;
+    if (token) {
+        headers.Authorization = token.startsWith('Bearer ') ? token : `Bearer ${token}`;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    try {
+        const response = await fetch(requestUrl.toString(), {
+            headers,
+            signal: controller.signal,
+        });
+
+        clearTimeout(timeout);
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            return buildJsonResponse(response.status, {
+                error: 'Failed to fetch events from Intickets.',
+                details: errorText,
+            });
+        }
+
+        const data = await response.json();
+
+        return buildJsonResponse(200, data, {
+            'Cache-Control': 's-maxage=300, stale-while-revalidate=600',
+        });
+    } catch (error) {
+        const isTimeout = error.name === 'AbortError';
+        const statusCode = isTimeout ? 504 : 500;
+
+        return buildJsonResponse(statusCode, {
+            error: 'Unable to fetch events from Intickets.',
+            details: error.message,
+        });
+    }
+}
+
+async function handleRequest(method, query) {
+    if (method === 'OPTIONS') {
+        return buildJsonResponse(200, null);
+    }
+
+    if (method !== 'GET') {
+        return buildJsonResponse(405, {
+            error: 'Method Not Allowed',
+        }, {
+            Allow: 'GET,OPTIONS',
+        });
+    }
+
+    return fetchEvents(query);
+}
+
+module.exports = async function vercelHandler(req, res) {
+    const result = await handleRequest(req.method, req.query || {});
+
+    Object.entries(result.headers || {}).forEach(([key, value]) => {
+        res.setHeader(key, value);
+    });
+
+    res.status(result.statusCode);
+    res.send(result.body);
+};
+
+module.exports.config = {
+    api: {
+        bodyParser: false,
+    },
+};
+
+const netlifyHandler = async function (event) {
+    const result = await handleRequest(event.httpMethod, event.queryStringParameters || {});
+    return result;
+};
+
+module.exports.handler = netlifyHandler;
+exports.handler = netlifyHandler;

--- a/index.html
+++ b/index.html
@@ -534,6 +534,191 @@
             background: linear-gradient(145deg, rgba(216, 178, 93, 0.12), rgba(0,0,0,0.75));
         }
 
+        .afisha-preview {
+            margin: 5rem 0;
+            padding: 2.75rem;
+            border-radius: 24px;
+            background: linear-gradient(135deg, rgba(216, 178, 93, 0.18), rgba(15, 15, 15, 0.65));
+            border: 1px solid rgba(216, 178, 93, 0.28);
+            box-shadow: 0 28px 60px rgba(0, 0, 0, 0.35);
+        }
+
+        .afisha-preview-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .afisha-preview-title {
+            margin: 0;
+            font-family: 'Cinzel', serif;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            font-size: clamp(1.5rem, 4vw, 2.4rem);
+        }
+
+        .afisha-preview-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.6rem 1.6rem;
+            border-radius: 999px;
+            border: 1px solid rgba(216, 178, 93, 0.45);
+            text-transform: uppercase;
+            letter-spacing: 0.12em;
+            font-size: 0.85rem;
+            color: var(--accent);
+            transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+        }
+
+        .afisha-preview-link::after {
+            content: '→';
+            font-size: 1.05rem;
+        }
+
+        .afisha-preview-link:hover,
+        .afisha-preview-link:focus-visible {
+            background: rgba(216, 178, 93, 0.18);
+            border-color: var(--accent);
+            color: var(--text);
+        }
+
+        .afisha-preview-grid {
+            display: grid;
+            gap: 1.8rem;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        .afisha-card {
+            display: flex;
+            flex-direction: column;
+            border-radius: 18px;
+            background: rgba(17, 17, 17, 0.85);
+            border: 1px solid rgba(216, 178, 93, 0.28);
+            overflow: hidden;
+            min-height: 100%;
+            transition: transform 0.35s ease, border-color 0.35s ease;
+            box-shadow: 0 18px 48px rgba(0, 0, 0, 0.35);
+            backdrop-filter: blur(16px);
+        }
+
+        .afisha-card:hover,
+        .afisha-card:focus-within {
+            transform: translateY(-6px);
+            border-color: rgba(216, 178, 93, 0.5);
+        }
+
+        .afisha-card__poster {
+            position: relative;
+            padding-top: 133%;
+            background: linear-gradient(135deg, rgba(216, 178, 93, 0.12), rgba(17, 17, 17, 0.9));
+            overflow: hidden;
+        }
+
+        .afisha-card__poster img {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .afisha-card__body {
+            display: flex;
+            flex-direction: column;
+            gap: 0.65rem;
+            padding: 1.25rem 1.25rem 0;
+        }
+
+        .afisha-card__title {
+            margin: 0;
+            font-size: 1.05rem;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+        }
+
+        .afisha-card__meta {
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+            font-size: 0.92rem;
+            color: rgba(247, 247, 247, 0.75);
+        }
+
+        .afisha-card__meta-row {
+            display: inline-flex;
+            gap: 0.45rem;
+            align-items: center;
+        }
+
+        .afisha-card__meta-label {
+            font-size: 0.72rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: rgba(247, 247, 247, 0.55);
+        }
+
+        .afisha-card__description {
+            margin: 0;
+            color: rgba(247, 247, 247, 0.8);
+            font-size: 0.92rem;
+            line-height: 1.55;
+        }
+
+        .afisha-card__footer {
+            margin-top: auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 1.25rem;
+        }
+
+        .afisha-card__price {
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--accent);
+        }
+
+        .afisha-card__link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            padding: 0.55rem 1.2rem;
+            border-radius: 999px;
+            border: 1px solid rgba(216, 178, 93, 0.35);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            font-size: 0.82rem;
+            color: var(--text);
+            transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+        }
+
+        .afisha-card__link::after {
+            content: '→';
+            font-size: 1.05rem;
+        }
+
+        .afisha-card__link:hover,
+        .afisha-card__link:focus-visible {
+            background: rgba(216, 178, 93, 0.2);
+            border-color: var(--accent);
+        }
+
+        .afisha-status {
+            margin: 0;
+            padding: 2rem;
+            text-align: center;
+            border-radius: 18px;
+            border: 1px dashed rgba(216, 178, 93, 0.35);
+            color: rgba(247, 247, 247, 0.7);
+            background: rgba(16, 16, 16, 0.6);
+        }
+
         .contact-info {
             display: flex;
             flex-direction: column;
@@ -636,6 +821,24 @@
             .repertoire-card {
                 padding: 1.5rem;
             }
+
+            .afisha-preview {
+                padding: 2.1rem 1.6rem;
+            }
+
+            .afisha-preview-header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 1rem;
+            }
+
+            .afisha-preview-link {
+                align-self: flex-start;
+            }
+
+            .afisha-preview-grid {
+                grid-template-columns: 1fr;
+            }
         }
 
         @media (max-width: 560px) {
@@ -700,6 +903,15 @@
                 padding: 1.8rem;
             }
 
+            .afisha-preview {
+                margin: 3.5rem 0;
+                padding: 1.8rem 1.4rem;
+            }
+
+            .afisha-preview-grid {
+                gap: 1.2rem;
+            }
+
             .social-buttons {
                 gap: 0.75rem;
             }
@@ -717,6 +929,7 @@
                     <li><a href="#about">О центре</a></li>
                     <li><a href="#repertoire">Репертуар</a></li>
                     <li><a href="#team">Команда</a></li>
+                    <li><a href="afisha.html">Афиша</a></li>
                     <li><a href="#contacts">Контакты</a></li>
                 </ul>
             </nav>
@@ -902,6 +1115,16 @@
             </div>
         </section>
 
+        <section class="afisha-preview" data-afisha-root data-afisha-limit="3">
+            <div class="afisha-preview-header">
+                <h2 class="afisha-preview-title">Ближайшие события</h2>
+                <a class="afisha-preview-link" href="afisha.html">Вся афиша</a>
+            </div>
+            <div class="afisha-preview-grid" data-afisha-grid>
+                <p class="afisha-status">Загружаем события…</p>
+            </div>
+        </section>
+
         <section id="team">
             <h2 class="section-title">Команда</h2>
             <div class="team-grid">
@@ -959,6 +1182,7 @@
         © 2024 AmmA Production. Все права защищены.
     </footer>
 
+    <script src="afisha.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             const slider = document.querySelector('.hero-slider');


### PR DESCRIPTION
## Summary
- добавлена серверная функция `/api/intickets-events` для безопасного обращения к Intickets с поддержкой Vercel и Netlify
- создана страница `afisha.html` со стилями и JS-виджетом, который строит сетку событий из API
- расширена главная страница предпросмотром афиши и ссылкой, обновлена документация и пример `.env`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d104b0e8d08322b37e9bd7f68d48db