### PR TITLE
Centralise Intickets widget config and fallback links

### DIFF
--- a/api/intickets-events.js
+++ b/api/intickets-events.js
@@ -1,0 +1,77 @@
+const DEFAULT_CACHE_SECONDS = 60;
+
+function buildResponse(res, statusCode, payload) {
+    if (typeof res.status === 'function') {
+        res.status(statusCode);
+    } else {
+        res.statusCode = statusCode;
+    }
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    const cacheControl = statusCode >= 400 ? 'no-store' : `public, max-age=${DEFAULT_CACHE_SECONDS}`;
+    res.setHeader('Cache-Control', cacheControl);
+    res.end(JSON.stringify(payload));
+}
+
+export default async function handler(req, res) {
+    const apiUrl = process.env.INTICKETS_EVENTS_URL;
+    const token = process.env.INTICKETS_TOKEN;
+
+    if (!apiUrl) {
+        return buildResponse(res, 500, {
+            error: 'Configuration error',
+            detail: 'INTICKETS_EVENTS_URL environment variable is not set.'
+        });
+    }
+
+    try {
+        const headers = { Accept: 'application/json' };
+        if (token) {
+            headers.Authorization = `Bearer ${token}`;
+        }
+
+        const upstreamResponse = await fetch(apiUrl, { headers });
+
+        if (!upstreamResponse.ok) {
+            const detail = await upstreamResponse.text();
+            return buildResponse(res, upstreamResponse.status, {
+                error: `Upstream error ${upstreamResponse.status}`,
+                detail
+            });
+        }
+
+        const payload = await upstreamResponse.json();
+        const events = normaliseEvents(payload);
+
+        return buildResponse(res, 200, { events });
+    } catch (error) {
+        return buildResponse(res, 500, {
+            error: 'Proxy failed',
+            detail: error instanceof Error ? error.message : String(error)
+        });
+    }
+}
+
+function normaliseEvents(payload) {
+    const items = Array.isArray(payload)
+        ? payload
+        : Array.isArray(payload?.events)
+        ? payload.events
+        : Array.isArray(payload?.data)
+        ? payload.data
+        : [];
+
+    return items.map((event) => ({
+        id: event?.id ?? event?.event_id ?? event?.slug ?? null,
+        title: event?.title ?? event?.name ?? 'Без названия',
+        date: event?.date ?? event?.datetime_start ?? event?.starts_at ?? event?.start_date ?? null,
+        venue: event?.venue?.name ?? event?.venue ?? event?.place ?? event?.location ?? '',
+        image:
+            event?.image?.url ??
+            event?.image ??
+            event?.poster ??
+            event?.cover ??
+            event?.photos?.[0]?.url ??
+            null,
+        url: event?.url ?? event?.seance_url ?? event?.link ?? null
+    }));
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1632 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AmmA Production — продюсерский центр</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;700&family=Montserrat:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="//s3.intickets.ru/intickets.min.css">
+    <link rel="stylesheet" href="//s3.intickets.ru/intickets-button-simple.min.css">
+    <script src="//s3.intickets.ru/intickets.js"></script>
+    <style>
+        :root {
+            --background: #0f0f0f;
+            --background-alt: #171717;
+            --text: #f7f7f7;
+            --muted: #cfcfcf;
+            --accent: #d8b25d;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Montserrat', 'Segoe UI', Tahoma, sans-serif;
+            background: var(--background);
+            color: var(--text);
+            line-height: 1.6;
+        }
+
+        a {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        header {
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            background: rgba(12, 12, 12, 0.95);
+            backdrop-filter: blur(8px);
+            border-bottom: 1px solid rgba(216, 178, 93, 0.3);
+        }
+
+        .nav-container {
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 1rem 1.5rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1.5rem;
+        }
+
+        .logo {
+            font-weight: 700;
+            letter-spacing: 0.15em;
+            text-transform: uppercase;
+            font-size: 1.1rem;
+        }
+
+        nav ul {
+            list-style: none;
+            display: flex;
+            gap: 1.25rem;
+            margin: 0;
+            padding: 0;
+        }
+
+        nav a {
+            font-size: 0.95rem;
+            color: var(--muted);
+            position: relative;
+            transition: color 0.3s ease;
+        }
+
+        nav a::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: -0.35rem;
+            width: 100%;
+            height: 2px;
+            background: var(--accent);
+            transform: scaleX(0);
+            transform-origin: right;
+            transition: transform 0.3s ease;
+        }
+
+        nav a:hover {
+            color: var(--text);
+        }
+
+        nav a:hover::after {
+            transform: scaleX(1);
+            transform-origin: left;
+        }
+
+        main {
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 0 1.5rem 4rem;
+        }
+
+        .hero {
+            position: relative;
+            padding: 2.5rem 0 4.5rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+            gap: 2rem;
+        }
+
+        .hero-heading {
+            margin: 0;
+            display: inline-flex;
+            flex-direction: column;
+            gap: 0.6rem;
+            font-family: 'Cinzel', serif;
+            font-weight: 400;
+            letter-spacing: 0.2em;
+            align-items: center;
+            text-align: center;
+        }
+
+        .hero-brand {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.35em;
+            font-size: clamp(3.4rem, 7vw, 5.4rem);
+            line-height: 0.95;
+            text-transform: uppercase;
+        }
+
+        .hero-letter {
+            display: inline-block;
+        }
+
+        .hero-letter-large {
+            font-size: 1em;
+        }
+
+        .hero-letter-small {
+            font-size: 0.72em;
+            letter-spacing: 0.2em;
+        }
+
+        .hero-production {
+            font-size: clamp(1.2rem, 3vw, 1.9rem);
+            letter-spacing: 0.75em;
+            text-transform: uppercase;
+            padding-top: 0.75rem;
+            border-top: 1px solid rgba(247, 247, 247, 0.25);
+        }
+
+        .hero-director {
+            margin-top: 1.4rem;
+            display: inline-flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.4rem;
+            color: var(--accent);
+            text-transform: uppercase;
+            letter-spacing: 0.18em;
+            font-weight: 600;
+        }
+
+        .hero-director-label {
+            font-size: 0.7rem;
+            color: var(--accent);
+        }
+
+        .hero-director-name {
+            font-size: 0.95rem;
+            letter-spacing: 0.25em;
+            color: var(--accent);
+            margin-top: 0.4rem;
+        }
+
+        .hero p {
+            max-width: 640px;
+            color: var(--muted);
+            margin: 0 auto;
+        }
+
+        .banner {
+            width: 100%;
+            max-width: 960px;
+            margin: 0 auto;
+            border: 1px solid rgba(216, 178, 93, 0.4);
+            border-radius: 24px;
+            overflow: hidden;
+            position: relative;
+            min-height: 320px;
+            background: var(--background-alt);
+        }
+
+        .banner-item {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            text-align: center;
+            padding: 3rem 2rem;
+            gap: 1.4rem;
+            opacity: 0;
+            visibility: hidden;
+            pointer-events: none;
+            transform: translateY(18px);
+            transition: opacity 0.9s ease, transform 0.9s ease;
+            color: var(--text);
+            isolate: isolate;
+        }
+
+        .banner-item::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background:
+                linear-gradient(120deg, rgba(12, 12, 12, 0.78), rgba(12, 12, 12, 0.55)),
+                var(--slide-bg, radial-gradient(circle at top, rgba(216,178,93,0.2), transparent 70%));
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
+            z-index: -2;
+            transition: transform 1.2s ease;
+        }
+
+        .banner-item::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(180deg, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.55));
+            z-index: -1;
+        }
+
+        .banner-item.is-active {
+            opacity: 1;
+            visibility: visible;
+            pointer-events: auto;
+            transform: translateY(0);
+        }
+
+        .banner-item.is-active::before {
+            transform: scale(1.04);
+        }
+
+        .banner-item-brand {
+            gap: 1.6rem;
+            --slide-bg: radial-gradient(circle at 20% 20%, rgba(216, 178, 93, 0.35), transparent 60%),
+                         linear-gradient(135deg, rgba(255,255,255,0.05), rgba(0,0,0,0.85));
+        }
+
+        .banner-title {
+            font-size: clamp(1.8rem, 4vw, 2.8rem);
+            font-weight: 700;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        .banner-date {
+            font-size: 0.85rem;
+            letter-spacing: 0.28em;
+            text-transform: uppercase;
+            padding: 0.55rem 1.6rem;
+            border-radius: 999px;
+            border: 1px solid rgba(216, 178, 93, 0.65);
+            background: rgba(12, 12, 12, 0.55);
+            color: var(--accent);
+        }
+
+        .banner-cta {
+            padding: 0.85rem 2.5rem;
+            border-radius: 999px;
+            border: 1px solid rgba(216, 178, 93, 0.7);
+            color: var(--background);
+            background: var(--accent);
+            font-weight: 600;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .banner-cta:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 10px 25px rgba(216, 178, 93, 0.2);
+        }
+
+        section {
+            margin-top: 5rem;
+        }
+
+        .section-title {
+            font-size: clamp(1.8rem, 3vw, 2.4rem);
+            margin-bottom: 1.5rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+        }
+
+        .about {
+            display: grid;
+            gap: 2rem;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            background: linear-gradient(145deg, rgba(255,255,255,0.03), rgba(0,0,0,0));
+            border-radius: 20px;
+            padding: 2.5rem;
+            border: 1px solid rgba(216, 178, 93, 0.2);
+        }
+
+        .about p {
+            margin: 0;
+            color: var(--muted);
+        }
+
+        .widget {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            padding: 2rem;
+            border-radius: 18px;
+            border: 1px solid rgba(216, 178, 93, 0.2);
+            background: var(--background-alt);
+        }
+
+        .widget a {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.9rem 1.8rem;
+            border-radius: 999px;
+            background: transparent;
+            border: 1px solid var(--accent);
+            color: var(--accent);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-weight: 600;
+            transition: background 0.3s ease, color 0.3s ease;
+        }
+
+        .widget a:hover {
+            background: var(--accent);
+            color: var(--background);
+        }
+
+        .afisha {
+            margin-top: 4rem;
+            padding: 3rem;
+            border-radius: 24px;
+            border: 1px solid rgba(216, 178, 93, 0.18);
+            background: linear-gradient(145deg, rgba(255, 255, 255, 0.02), rgba(0, 0, 0, 0));
+            display: flex;
+            flex-direction: column;
+            gap: 1.8rem;
+        }
+
+        .afisha-header {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1.25rem;
+        }
+
+        .afisha-description {
+            margin: 0;
+            max-width: 560px;
+            color: var(--muted);
+        }
+
+        .afisha-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
+
+        .afisha-field {
+            position: relative;
+            flex: 1 1 220px;
+        }
+
+        .afisha-field input,
+        .afisha-field select {
+            width: 100%;
+            padding: 0.85rem 1.1rem;
+            border-radius: 14px;
+            border: 1px solid rgba(216, 178, 93, 0.28);
+            background: rgba(17, 17, 17, 0.92);
+            color: var(--text);
+            font-size: 0.95rem;
+            letter-spacing: 0.03em;
+        }
+
+        .afisha-status {
+            padding: 0.75rem 1rem;
+            border-radius: 14px;
+            border: 1px solid rgba(216, 178, 93, 0.28);
+            background: rgba(216, 178, 93, 0.1);
+            color: var(--accent);
+            font-size: 0.9rem;
+        }
+
+        .afisha-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .afisha-card {
+            display: flex;
+            flex-direction: column;
+            border-radius: 20px;
+            border: 1px solid rgba(216, 178, 93, 0.18);
+            background: linear-gradient(160deg, rgba(255, 255, 255, 0.02), rgba(0, 0, 0, 0.65));
+            overflow: hidden;
+            min-height: 100%;
+            transition: transform 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+        }
+
+        .afisha-card:hover {
+            transform: translateY(-4px);
+            border-color: rgba(216, 178, 93, 0.45);
+            box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
+        }
+
+        .afisha-card-cover {
+            position: relative;
+            width: 100%;
+            aspect-ratio: 16 / 10;
+            background: rgba(15, 15, 15, 0.72);
+            overflow: hidden;
+        }
+
+        .afisha-card-cover img {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            transition: transform 0.4s ease;
+        }
+
+        .afisha-card:hover .afisha-card-cover img {
+            transform: scale(1.05);
+        }
+
+        .afisha-card-body {
+            display: flex;
+            flex-direction: column;
+            gap: 0.85rem;
+            padding: 1.6rem 1.6rem 1.8rem;
+        }
+
+        .afisha-card-title {
+            margin: 0;
+            font-size: 1.1rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        .afisha-card-meta {
+            color: var(--muted);
+            font-size: 0.92rem;
+            letter-spacing: 0.04em;
+        }
+
+        .afisha-card-actions {
+            margin-top: auto;
+            display: flex;
+            gap: 0.75rem;
+        }
+
+        .afisha-card-actions .btn {
+            flex: 1;
+            border-radius: 999px;
+            padding: 0.75rem 1.1rem;
+            font-size: 0.88rem;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-weight: 600;
+            background: var(--accent);
+            border: 1px solid rgba(216, 178, 93, 0.8);
+            color: var(--background);
+            text-decoration: none;
+            transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
+        }
+
+        .afisha-card-actions .btn:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 12px 24px rgba(216, 178, 93, 0.25);
+        }
+
+        .btn-ghost {
+            background: transparent;
+            color: var(--accent);
+            border: 1px solid rgba(216, 178, 93, 0.55);
+        }
+
+        .btn-ghost:hover {
+            background: rgba(216, 178, 93, 0.12);
+            color: var(--text);
+        }
+
+        .afisha-empty {
+            padding: 1.6rem;
+            border-radius: 18px;
+            border: 1px dashed rgba(216, 178, 93, 0.4);
+            text-align: center;
+            color: var(--muted);
+            letter-spacing: 0.05em;
+        }
+
+        .afisha-card.afisha-card--skeleton {
+            position: relative;
+            overflow: hidden;
+        }
+
+        .afisha-card.afisha-card--skeleton::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(120deg, rgba(247, 247, 247, 0), rgba(247, 247, 247, 0.12), rgba(247, 247, 247, 0));
+            animation: shimmer 1.6s infinite;
+        }
+
+        .afisha-card.afisha-card--skeleton * {
+            visibility: hidden;
+        }
+
+        .visually-hidden {
+            position: absolute !important;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
+        @keyframes shimmer {
+            0% {
+                transform: translateX(-100%);
+            }
+            100% {
+                transform: translateX(100%);
+            }
+        }
+
+        .repertoire-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .repertoire-card {
+            padding: 1.75rem;
+            border-radius: 18px;
+            background: linear-gradient(160deg, rgba(255,255,255,0.05), rgba(0,0,0,0.8));
+            border: 1px solid rgba(216, 178, 93, 0.2);
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .repertoire-media {
+            width: 100%;
+            aspect-ratio: 4 / 3;
+            border-radius: 14px;
+            overflow: hidden;
+            background: rgba(247, 247, 247, 0.08);
+        }
+
+        .repertoire-media svg {
+            width: 100%;
+            height: 100%;
+            display: block;
+        }
+
+        .repertoire-card span {
+            text-transform: uppercase;
+            font-size: 0.8rem;
+            letter-spacing: 0.3em;
+            color: var(--accent);
+        }
+
+        .repertoire-card h3 {
+            margin: 0;
+        }
+
+        .repertoire-card p {
+            margin: 0;
+            color: var(--muted);
+        }
+
+        .team-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 1.25rem;
+        }
+
+        .team-card {
+            border: 1px solid rgba(216, 178, 93, 0.2);
+            border-radius: 18px;
+            padding: 1.8rem;
+            background: var(--background-alt);
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .team-card strong {
+            letter-spacing: 0.05em;
+            font-size: 1.1rem;
+        }
+
+        .team-card span {
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .contacts {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 2rem;
+            padding: 2.5rem;
+            border: 1px solid rgba(216, 178, 93, 0.2);
+            border-radius: 20px;
+            background: linear-gradient(145deg, rgba(216, 178, 93, 0.12), rgba(0,0,0,0.75));
+        }
+
+        .contact-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .contact-info a {
+            color: var(--accent);
+        }
+
+        .social-buttons {
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .social-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.75rem 1.4rem;
+            border-radius: 999px;
+            border: 1px solid rgba(216, 178, 93, 0.5);
+            color: var(--text);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            font-size: 0.85rem;
+            transition: transform 0.3s ease, background 0.3s ease;
+        }
+
+        .social-button svg {
+            width: 18px;
+            height: 18px;
+            fill: currentColor;
+        }
+
+        .social-button:hover {
+            transform: translateY(-3px);
+            background: rgba(216, 178, 93, 0.15);
+        }
+
+        footer {
+            margin-top: 4rem;
+            padding: 2rem 1.5rem;
+            text-align: center;
+            color: var(--muted);
+            border-top: 1px solid rgba(216, 178, 93, 0.2);
+        }
+
+        @media (max-width: 768px) {
+            nav ul {
+                display: none;
+            }
+
+            header {
+                position: static;
+            }
+
+            .hero {
+                padding: 2.4rem 0 3.2rem;
+            }
+
+            .hero-brand {
+                gap: 0.25em;
+                flex-wrap: wrap;
+            }
+
+            .hero-director {
+                letter-spacing: 0.14em;
+            }
+
+            .banner {
+                border-radius: 16px;
+                min-height: 280px;
+            }
+
+            .banner-item {
+                padding: 2.4rem 1.6rem;
+            }
+
+            .afisha {
+                padding: 2.4rem 2rem;
+                gap: 1.6rem;
+            }
+
+            .afisha-header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 0.75rem;
+            }
+
+            .afisha-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .afisha-card-body {
+                padding: 1.4rem 1.4rem 1.6rem;
+            }
+
+            .repertoire-card {
+                padding: 1.5rem;
+            }
+        }
+
+        @media (max-width: 560px) {
+            main {
+                padding: 0 1rem 3.5rem;
+            }
+
+            .hero-brand {
+                font-size: clamp(2.4rem, 14vw, 3.2rem);
+                letter-spacing: 0.12em;
+            }
+
+            .hero-production {
+                letter-spacing: 0.45em;
+                font-size: clamp(1rem, 6vw, 1.35rem);
+            }
+
+            .hero-director-name {
+                letter-spacing: 0.18em;
+            }
+
+            .banner {
+                min-height: 250px;
+            }
+
+            .banner-item {
+                padding: 2rem 1.25rem;
+            }
+
+            .banner-title {
+                font-size: clamp(1.5rem, 6vw, 2.1rem);
+            }
+
+            .banner-date {
+                font-size: 0.72rem;
+                letter-spacing: 0.18em;
+                padding: 0.45rem 1.2rem;
+            }
+
+            .afisha {
+                padding: 1.8rem 1.2rem;
+                gap: 1.4rem;
+            }
+
+            .afisha-card-body {
+                padding: 1.25rem 1.25rem 1.4rem;
+            }
+
+            .afisha-card-title {
+                font-size: 1rem;
+            }
+
+            .afisha-card-meta {
+                font-size: 0.88rem;
+            }
+
+            .repertoire-media {
+                aspect-ratio: 3 / 2;
+            }
+
+            .contacts {
+                padding: 1.8rem;
+            }
+
+            .social-buttons {
+                gap: 0.75rem;
+            }
+        }
+
+    </style>
+</head>
+<body>
+    <header>
+        <div class="nav-container">
+            <div class="logo">AmmA Production</div>
+            <nav>
+                <ul>
+                    <li><a href="#about">О центре</a></li>
+                    <li><a href="#repertoire">Репертуар</a></li>
+                    <li><a href="#team">Команда</a></li>
+                    <li><a href="#contacts">Контакты</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero" id="about">
+            <div class="banner hero-slider" aria-label="Анимированный баннер AmmA Production">
+                <div class="banner-item banner-item-brand is-active">
+                    <h1 class="hero-heading" aria-label="AmmA Production">
+                        <span class="hero-brand" aria-hidden="true">
+                            <span class="hero-letter hero-letter-large">A</span>
+                            <span class="hero-letter hero-letter-small">M</span>
+                            <span class="hero-letter hero-letter-small">M</span>
+                            <span class="hero-letter hero-letter-large">A</span>
+                        </span>
+                        <span class="hero-production" aria-hidden="true">PRODUCTION</span>
+                    </h1>
+                    <div class="hero-director" aria-label="Художественный руководитель — Вера Анненкова">
+                        <span class="hero-director-label">Художественный руководитель</span>
+                        <span class="hero-director-name">Вера Анненкова</span>
+                    </div>
+                </div>
+                <div class="banner-item" style="--slide-bg: url('https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=1200&q=80');">
+                    <div class="banner-date">12 апреля 2024</div>
+                    <div class="banner-title">«Мой бедный Марат»</div>
+                    <a class="banner-cta" href="https://iframeab-pre2514.intickets.ru/seance/60835614/#abiframe" target="_blank" rel="noopener">Купить билет</a>
+                </div>
+                <div class="banner-item" style="--slide-bg: url('https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80');">
+                    <div class="banner-date">26 апреля 2024</div>
+                    <div class="banner-title">«Окна. Город. Любовь...»</div>
+                    <a class="banner-cta" href="https://iframeab-pre2514.intickets.ru/seance/60835614/#abiframe" target="_blank" rel="noopener">Купить билет</a>
+                </div>
+                <div class="banner-item" style="--slide-bg: url('https://images.unsplash.com/photo-1500375592092-40eb2168fd21?auto=format&fit=crop&w=1200&q=80');">
+                    <div class="banner-date">14 мая 2024</div>
+                    <div class="banner-title">«Остров»</div>
+                    <a class="banner-cta" href="https://iframeab-pre2514.intickets.ru/seance/60835614/#abiframe" target="_blank" rel="noopener">Купить билет</a>
+                </div>
+            </div>
+            <p>Продюсерский центр нового поколения, объединяющий драматическое искусство, современный визуальный язык и авторские творческие решения. Мы создаём спектакли, которые говорят с публикой на одном языке и оставляют послевкусие настоящего театра.</p>
+        </section>
+
+        <section class="afisha" id="playbill" data-afisha>
+            <div class="afisha-header">
+                <h2 class="section-title">Афиша</h2>
+                <p class="afisha-description">Предстоящие спектакли AmmA Production синхронизируются с Intickets через наш серверный прокси. Используйте поиск и сортировку, чтобы быстрее найти нужное событие.</p>
+            </div>
+            <div class="afisha-controls">
+                <label class="afisha-field">
+                    <span class="visually-hidden">Поиск по названию спектакля</span>
+                    <input type="search" placeholder="Поиск по названию…" data-afisha-search autocomplete="off">
+                </label>
+                <label class="afisha-field">
+                    <span class="visually-hidden">Сортировка по дате события</span>
+                    <select data-afisha-sort>
+                        <option value="date_asc">Ближайшие сначала</option>
+                        <option value="date_desc">Дальние сначала</option>
+                    </select>
+                </label>
+            </div>
+            <div class="afisha-status" data-afisha-status hidden></div>
+            <div class="afisha-grid" data-afisha-grid aria-live="polite" aria-busy="true"></div>
+            <div class="afisha-empty" data-afisha-empty hidden>События не найдены.</div>
+        </section>
+        <section>
+            <div class="about">
+                <div>
+                    <h2 class="section-title">О центре</h2>
+                    <p>AmmA Production сопровождает культурные проекты на всех этапах — от идеи до премьерного поклона. Наша команда курирует постановки, гастроли, медиасопровождение и работу с партнёрами, создавая актуальные театральные события.</p>
+                </div>
+                <div class="widget">
+                    <h3 style="margin:0; font-size:1.2rem; text-transform:uppercase; letter-spacing:0.08em;">Онлайн-билеты</h3>
+                    <p style="margin:0; color:var(--muted);">Используйте готовый виджет для моментальной покупки билетов на спектакли нашего репертуара.</p>
+                    <a href="https://iframeab-pre2514.intickets.ru/seance/60835614/#abiframe">Купить билет</a>
+                </div>
+            </div>
+        </section>
+
+        <section id="repertoire">
+            <h2 class="section-title">Текущий репертуар</h2>
+            <div class="repertoire-grid">
+                <div class="repertoire-card">
+                    <figure class="repertoire-media">
+                        <svg viewBox="0 0 320 240" role="img" aria-labelledby="poster-marat" xmlns="http://www.w3.org/2000/svg">
+                            <title id="poster-marat">Стилизованная афиша спектакля «Мой бедный Марат»</title>
+                            <defs>
+                                <linearGradient id="marat-bg" x1="0" y1="0" x2="1" y2="1">
+                                    <stop offset="0%" stop-color="#1c1c1c" />
+                                    <stop offset="100%" stop-color="#0b0b0b" />
+                                </linearGradient>
+                                <linearGradient id="marat-accent" x1="0" y1="0" x2="1" y2="1">
+                                    <stop offset="0%" stop-color="#d8b25d" />
+                                    <stop offset="100%" stop-color="#8f6a1f" />
+                                </linearGradient>
+                            </defs>
+                            <rect width="320" height="240" fill="url(#marat-bg)" />
+                            <g opacity="0.25" stroke="#f7f7f7" stroke-opacity="0.4" stroke-width="2">
+                                <line x1="28" y1="52" x2="292" y2="52" />
+                                <line x1="28" y1="118" x2="292" y2="118" />
+                                <line x1="28" y1="184" x2="292" y2="184" />
+                            </g>
+                            <path d="M36 212 L160 38 L284 212 Z" fill="url(#marat-accent)" fill-opacity="0.68" />
+                            <path d="M72 212 L160 108 L248 212 Z" fill="none" stroke="#d8b25d" stroke-width="4" stroke-opacity="0.7" />
+                            <circle cx="160" cy="126" r="26" fill="#0f0f0f" stroke="#d8b25d" stroke-width="3" />
+                            <path d="M126 212 L150 166 L170 212 Z" fill="#101010" opacity="0.85" />
+                            <path d="M176 212 L190 186 L204 212 Z" fill="#0b0b0b" opacity="0.75" />
+                        </svg>
+                    </figure>
+                    <span>Драма</span>
+                    <h3>Мой бедный Марат</h3>
+                    <p>Пьеса Алексея Арбузова о молодости, любви и надежде, которая не угасает даже в самые тяжёлые времена.</p>
+                </div>
+                <div class="repertoire-card">
+                    <figure class="repertoire-media">
+                        <svg viewBox="0 0 320 240" role="img" aria-labelledby="poster-okna" xmlns="http://www.w3.org/2000/svg">
+                            <title id="poster-okna">Стилизованная афиша спектакля «Окна. Город. Любовь...»</title>
+                            <defs>
+                                <linearGradient id="okna-bg" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#1e1e1e" />
+                                    <stop offset="100%" stop-color="#090909" />
+                                </linearGradient>
+                                <linearGradient id="okna-highlight" x1="0" y1="0" x2="1" y2="1">
+                                    <stop offset="0%" stop-color="#d8b25d" stop-opacity="0.9" />
+                                    <stop offset="100%" stop-color="#b48b3f" stop-opacity="0.6" />
+                                </linearGradient>
+                            </defs>
+                            <rect width="320" height="240" fill="url(#okna-bg)" />
+                            <g stroke="#f7f7f7" stroke-width="3" stroke-opacity="0.08">
+                                <line x1="40" y1="30" x2="280" y2="30" />
+                                <line x1="40" y1="90" x2="280" y2="90" />
+                                <line x1="40" y1="150" x2="280" y2="150" />
+                                <line x1="40" y1="210" x2="280" y2="210" />
+                                <line x1="40" y1="30" x2="40" y2="210" />
+                                <line x1="110" y1="30" x2="110" y2="210" />
+                                <line x1="190" y1="30" x2="190" y2="210" />
+                                <line x1="280" y1="30" x2="280" y2="210" />
+                            </g>
+                            <g fill="url(#okna-highlight)" fill-opacity="0.85">
+                                <rect x="56" y="48" width="40" height="60" rx="6" />
+                                <rect x="126" y="110" width="48" height="70" rx="6" />
+                                <rect x="206" y="60" width="52" height="82" rx="6" />
+                            </g>
+                            <g fill="#d8b25d" fill-opacity="0.4">
+                                <rect x="62" y="164" width="28" height="36" rx="4" />
+                                <rect x="138" y="70" width="26" height="32" rx="4" />
+                                <rect x="216" y="162" width="34" height="44" rx="4" />
+                            </g>
+                            <path d="M36 212 H284" stroke="#d8b25d" stroke-width="4" stroke-linecap="round" stroke-opacity="0.6" />
+                        </svg>
+                    </figure>
+                    <span>Поэтический спектакль</span>
+                    <h3>Окна. Город. Любовь...</h3>
+                    <p>Погружение в городские истории, рассказанные языком пластики, видеоарта и живой музыки.</p>
+                </div>
+                <div class="repertoire-card">
+                    <figure class="repertoire-media">
+                        <svg viewBox="0 0 320 240" role="img" aria-labelledby="poster-ostrov" xmlns="http://www.w3.org/2000/svg">
+                            <title id="poster-ostrov">Стилизованная афиша спектакля «Остров»</title>
+                            <defs>
+                                <linearGradient id="ostrov-sky" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#161616" />
+                                    <stop offset="100%" stop-color="#050505" />
+                                </linearGradient>
+                                <linearGradient id="ostrov-glow" x1="0" y1="0" x2="1" y2="1">
+                                    <stop offset="0%" stop-color="#d8b25d" stop-opacity="0.85" />
+                                    <stop offset="100%" stop-color="#8d6f2c" stop-opacity="0.6" />
+                                </linearGradient>
+                            </defs>
+                            <rect width="320" height="240" fill="url(#ostrov-sky)" />
+                            <circle cx="236" cy="64" r="34" fill="url(#ostrov-glow)" fill-opacity="0.75" />
+                            <path d="M0 188 Q80 144 160 176 T320 188 V240 H0 Z" fill="#0c0c0c" />
+                            <path d="M92 188 Q120 150 160 164 Q200 178 228 188 Z" fill="#111" />
+                            <path d="M128 186 Q160 148 188 184 Z" fill="#d8b25d" fill-opacity="0.45" />
+                            <g stroke="#d8b25d" stroke-width="3" stroke-opacity="0.6" fill="none">
+                                <path d="M40 212 C80 204 120 204 160 212" />
+                                <path d="M160 212 C200 220 240 220 280 212" />
+                            </g>
+                            <g stroke="#f7f7f7" stroke-opacity="0.12" stroke-width="2" fill="none">
+                                <path d="M24 138 Q112 96 160 120 Q208 144 296 108" />
+                            </g>
+                        </svg>
+                    </figure>
+                    <span>Современная притча</span>
+                    <h3>Остров</h3>
+                    <p>Постановка о поиске себя и силе одиночества, объединяющая перформанс, медиа и авторскую музыку.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="team">
+            <h2 class="section-title">Команда</h2>
+            <div class="team-grid">
+                <div class="team-card">
+                    <strong>Вера Анненкова</strong>
+                    <span>Художественный руководитель</span>
+                </div>
+                <div class="team-card">
+                    <strong>Михаил Маликов</strong>
+                    <span>Продюсер</span>
+                </div>
+                <div class="team-card">
+                    <strong>Алина Мазненкова</strong>
+                    <span>PR и коммуникации</span>
+                </div>
+                <div class="team-card">
+                    <strong>Максим Дементьев</strong>
+                    <span>Технический директор</span>
+                </div>
+                <div class="team-card">
+                    <strong>Аксинья Олейник</strong>
+                    <span>Куратор проектов</span>
+                </div>
+            </div>
+        </section>
+
+        <section id="contacts">
+            <h2 class="section-title">Контакты</h2>
+            <div class="contacts">
+                <div class="contact-info">
+                    <div><strong>Телефон:</strong> <a href="tel:+79991234567">+7 (999) 123-45-67</a></div>
+                    <div><strong>Email:</strong> <a href="mailto:info@amma-production.ru">info@amma-production.ru</a></div>
+                    <div><strong>Адрес:</strong> Москва, Большая театральная, 12</div>
+                    <div><strong>График:</strong> Пн–Пт 10:00–19:00</div>
+                </div>
+                <div>
+                    <h3 style="margin-top:0; text-transform:uppercase; letter-spacing:0.08em;">Свяжитесь с нами</h3>
+                    <p style="color:var(--muted); margin-top:0;">Менеджеры AmmA Production готовы помочь с организацией показов, партнёрскими предложениями и покупкой билетов.</p>
+                    <div class="social-buttons">
+                        <a class="social-button" href="https://wa.me/79991234567" target="_blank" rel="noopener">
+                            <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M16.04 3C9.4 3 4 8.29 4 14.82c0 2.48.79 4.79 2.14 6.69L4 29l7.74-2.06c1.83 1 3.94 1.57 6.3 1.57 6.63 0 12.04-5.29 12.04-11.82C30.09 8.29 22.67 3 16.04 3zm0 20.97c-2.03 0-3.92-.56-5.52-1.53l-.39-.24-4.59 1.22 1.23-4.35-.26-.45a9.43 9.43 0 01-1.45-4.99c0-5.3 4.42-9.62 9.98-9.62s9.98 4.32 9.98 9.62-4.42 9.62-9.98 9.62zm5.76-7.18c-.31-.15-1.84-.9-2.12-1-.28-.1-.49-.15-.7.15-.21.31-.81 1-.99 1.2-.18.21-.37.23-.68.08-.31-.16-1.29-.47-2.46-1.5-.91-.81-1.53-1.81-1.71-2.12-.18-.31-.02-.48.13-.63.14-.14.31-.37.47-.55.15-.18.21-.31.31-.52.1-.21.05-.39-.02-.55-.08-.15-.7-1.68-.96-2.3-.25-.6-.51-.52-.7-.53l-.6-.01c-.21 0-.55.08-.84.39-.28.31-1.1 1.08-1.1 2.63s1.13 3.06 1.29 3.27c.16.21 2.23 3.38 5.41 4.73.76.33 1.35.53 1.81.68.76.24 1.45.21 2 .13.61-.09 1.84-.75 2.1-1.48.26-.73.26-1.36.18-1.48-.08-.13-.28-.21-.6-.37z"></path></svg>
+                            WhatsApp
+                        </a>
+                        <a class="social-button" href="https://t.me/amma_production" target="_blank" rel="noopener">
+                            <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M28.44 5.23L3.46 14.97c-1.69.66-1.68 1.58-.31 2.02l6.21 1.94 2.39 7.64c.29.81.15 1.14.99 1.14.65 0 .94-.3 1.31-.65l3.15-3.06 6.56 4.83c1.2.66 2.07.32 2.37-1.11l4.29-20.13c.44-1.76-.67-2.55-1.98-2.03zM25.4 9.3l-11.2 10.4c-.49.44-.18.69.29 1.11l3.36 2.86c.56.52 1.14.16 1.31-.29l2.53-7.56 4.59-4.35c.23-.21-.05-.5-.88-.17z"></path></svg>
+                            Telegram
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        © 2024 AmmA Production. Все права защищены.
+    </footer>
+
+    <script>
+        const INTICKETS_WIDGET_CONFIG = Object.freeze({
+            baseUrl: 'https://iframeab-pre2514.intickets.ru/',
+            anchor: '#abiframe'
+        });
+
+        const AFISHA_PLACEHOLDER_IMAGE = 'https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=1200&q=80';
+
+        const REPERTOIRE_FIXTURES = [
+            {
+                id: 'repertoire-marath',
+                slug: 'moi-bedny-marath',
+                title: 'Мой бедный Марат',
+                venue: 'Москва',
+                image: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80',
+                inticketsEventId: '11756122',
+                ticketPath: 'node/11756122',
+                detailsPath: 'event/11756122',
+                seances: [
+                    {
+                        datetime: '2024-04-12T19:00:00+03:00',
+                        seanceId: '60835614'
+                    }
+                ]
+            },
+            {
+                id: 'repertoire-okna',
+                slug: 'okna-gorod-lyubov',
+                title: 'Окна. Город. Любовь...',
+                venue: 'Москва',
+                image: 'https://images.unsplash.com/photo-1500375592092-40eb2168fd21?auto=format&fit=crop&w=1200&q=80',
+                detailsUrl: 'https://iframeab-pre2514.intickets.ru/events/#abiframe',
+                seances: [
+                    {
+                        datetime: '2024-04-26T19:00:00+03:00',
+                        directUrl: 'https://iframeab-pre2514.intickets.ru/events/#abiframe'
+                    }
+                ]
+            },
+            {
+                id: 'repertoire-ostrov',
+                slug: 'ostrov',
+                title: 'Остров',
+                venue: 'Санкт-Петербург',
+                image: 'https://images.unsplash.com/photo-1462212210333-335063b676d3?auto=format&fit=crop&w=1200&q=80',
+                detailsUrl: 'https://iframeab-pre2514.intickets.ru/events/#abiframe',
+                seances: [
+                    {
+                        datetime: '2024-05-14T19:00:00+03:00',
+                        directUrl: 'https://iframeab-pre2514.intickets.ru/events/#abiframe'
+                    }
+                ]
+            }
+        ];
+
+        const afishaFallbackEvents = buildFallbackAfishaEvents(REPERTOIRE_FIXTURES);
+
+        function buildFallbackAfishaEvents(fixtures) {
+            if (!Array.isArray(fixtures)) {
+                return [];
+            }
+
+            return fixtures.map((fixture) => {
+                const nextSeance = getNextSeanceEntry(fixture?.seances);
+                const seanceDescriptor = nextSeance
+                    ? {
+                          datetime: nextSeance.datetime ?? null,
+                          seanceId: nextSeance.seanceId ?? null,
+                          directUrl: nextSeance.directUrl ?? null
+                      }
+                    : null;
+
+                const eventIdentifier =
+                    fixture?.inticketsEventIdentifier ??
+                    (fixture?.inticketsEventId ? `node/${fixture.inticketsEventId}` : null) ??
+                    fixture?.eventIdentifier ??
+                    null;
+
+                const ticketSource =
+                    typeof fixture?.ticketPath === 'string' && fixture.ticketPath
+                        ? fixture.ticketPath
+                        : eventIdentifier;
+
+                const detailsSource =
+                    typeof fixture?.detailsPath === 'string' && fixture.detailsPath
+                        ? fixture.detailsPath
+                        : eventIdentifier;
+
+                const ticketUrl =
+                    typeof fixture?.ticketUrl === 'string' && fixture.ticketUrl
+                        ? fixture.ticketUrl
+                        : seanceDescriptor?.directUrl
+                        ? composeInticketsUrl(seanceDescriptor.directUrl, { anchor: true })
+                        : composeInticketsUrl(ticketSource, { seance: seanceDescriptor, anchor: true });
+
+                const detailsUrl =
+                    typeof fixture?.detailsUrl === 'string' && fixture.detailsUrl
+                        ? composeInticketsUrl(fixture.detailsUrl, { anchor: true })
+                        : composeInticketsUrl(detailsSource, { anchor: true });
+
+                return {
+                    id:
+                        fixture?.id ??
+                        fixture?.slug ??
+                        fixture?.inticketsEventId ??
+                        fixture?.title ??
+                        'afisha-event',
+                    title: fixture?.title ?? 'Без названия',
+                    venue: fixture?.venue ?? '',
+                    date: seanceDescriptor?.datetime ?? fixture?.date ?? null,
+                    image: fixture?.image ?? AFISHA_PLACEHOLDER_IMAGE,
+                    ticketUrl,
+                    detailsUrl,
+                    inticketsEventIdentifier: eventIdentifier,
+                    inticketsSeanceId: seanceDescriptor?.seanceId ?? null
+                };
+            });
+        }
+
+        function getNextSeanceEntry(seances) {
+            if (!Array.isArray(seances) || !seances.length) {
+                return null;
+            }
+
+            const normalised = seances
+                .map((entry) => {
+                    if (!entry) {
+                        return null;
+                    }
+
+                    const iso = entry.datetime ?? entry.date ?? null;
+                    const dateObject = iso ? new Date(iso) : null;
+                    const isValidDate = dateObject instanceof Date && !Number.isNaN(dateObject.getTime());
+
+                    if (!isValidDate && !entry.directUrl && !entry.seanceId && !entry.inticketsSeanceId) {
+                        return null;
+                    }
+
+                    return {
+                        datetime: isValidDate ? dateObject.toISOString() : iso,
+                        dateObject: isValidDate ? dateObject : null,
+                        seanceId: entry.seanceId ?? entry.inticketsSeanceId ?? null,
+                        directUrl: entry.directUrl ?? entry.seanceUrl ?? null
+                    };
+                })
+                .filter(Boolean);
+
+            if (!normalised.length) {
+                return null;
+            }
+
+            normalised.sort((a, b) => {
+                const aTime = a.dateObject ? a.dateObject.getTime() : Number.POSITIVE_INFINITY;
+                const bTime = b.dateObject ? b.dateObject.getTime() : Number.POSITIVE_INFINITY;
+                return aTime - bTime;
+            });
+
+            const now = new Date();
+            const upcoming = normalised.find((entry) => entry.dateObject && entry.dateObject.getTime() >= now.getTime());
+            const selected = upcoming || normalised[0];
+
+            return {
+                datetime: selected.datetime ?? null,
+                seanceId: selected.seanceId ?? null,
+                directUrl: selected.directUrl ?? null
+            };
+        }
+
+        function composeInticketsUrl(pathOrUrl, options = {}) {
+            const { seance, anchor = false } = options;
+            const baseUrl = normaliseBaseUrl(INTICKETS_WIDGET_CONFIG.baseUrl);
+            const anchorSuffix =
+                anchor && typeof INTICKETS_WIDGET_CONFIG.anchor === 'string'
+                    ? INTICKETS_WIDGET_CONFIG.anchor
+                    : '';
+            const seanceDescriptor = seance && typeof seance === 'object' ? seance : null;
+
+            let url = pathOrUrl ? String(pathOrUrl) : '';
+
+            if (!url) {
+                if (seanceDescriptor?.seanceId) {
+                    url = `${baseUrl}seance/${seanceDescriptor.seanceId}`;
+                } else if (seanceDescriptor?.datetime) {
+                    const suffix = formatInticketsScheduleSuffix(new Date(seanceDescriptor.datetime));
+                    url = suffix ? `${baseUrl.replace(/\/$/, '')}/${suffix}` : baseUrl || '#';
+                } else {
+                    url = baseUrl || '#';
+                }
+            } else if (!/^https?:/i.test(url)) {
+                url = `${baseUrl}${url.replace(/^\//, '')}`;
+            }
+
+            const hasSeancePath = /\/seance\/\d+/.test(url) || /\d{8}_\d{4}(?:[#/]|$)/.test(url);
+
+            if (seanceDescriptor && !hasSeancePath) {
+                if (seanceDescriptor.seanceId) {
+                    url = `${baseUrl}seance/${seanceDescriptor.seanceId}`;
+                } else if (seanceDescriptor.datetime) {
+                    const suffix = formatInticketsScheduleSuffix(new Date(seanceDescriptor.datetime));
+                    if (suffix) {
+                        const hashIndex = url.indexOf('#');
+                        const basePart = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+                        const hashPart = hashIndex >= 0 ? url.slice(hashIndex) : '';
+                        url = `${basePart.replace(/\/$/, '')}/${suffix}${hashPart}`;
+                    }
+                }
+            }
+
+            if (anchorSuffix && !url.includes('#')) {
+                url += anchorSuffix;
+            }
+
+            return url;
+        }
+
+        function normaliseBaseUrl(value) {
+            if (!value) {
+                return '';
+            }
+
+            return value.endsWith('/') ? value : `${value}/`;
+        }
+
+        document.addEventListener('DOMContentLoaded', function () {
+            initHeroSlider();
+            initAfishaSection();
+        });
+
+        function initHeroSlider() {
+            const slider = document.querySelector('.hero-slider');
+            if (!slider) {
+                return;
+            }
+
+            const slides = Array.from(slider.querySelectorAll('.banner-item'));
+            if (!slides.length) {
+                return;
+            }
+
+            const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            slides.forEach((slide, index) => {
+                slide.classList.toggle('is-active', index === 0);
+            });
+
+            if (reduceMotion || slides.length <= 1) {
+                return;
+            }
+
+            let current = 0;
+            const cycleDuration = 5000;
+            setInterval(() => {
+                slides[current].classList.remove('is-active');
+                current = (current + 1) % slides.length;
+                slides[current].classList.add('is-active');
+            }, cycleDuration);
+        }
+
+        function initAfishaSection() {
+            const section = document.querySelector('[data-afisha]');
+            if (!section) {
+                return;
+            }
+
+            const grid = section.querySelector('[data-afisha-grid]');
+            const empty = section.querySelector('[data-afisha-empty]');
+            const searchField = section.querySelector('[data-afisha-search]');
+            const sortField = section.querySelector('[data-afisha-sort]');
+            const statusField = section.querySelector('[data-afisha-status]');
+
+            if (grid) {
+                renderAfishaSkeleton(grid, 3);
+            }
+
+            let events = [];
+            let fallbackUsed = false;
+
+            if (searchField) {
+                searchField.addEventListener('input', () => renderAfisha());
+            }
+
+            if (sortField) {
+                sortField.addEventListener('change', () => renderAfisha());
+            }
+
+            fetchAfishaEvents();
+
+            async function fetchAfishaEvents() {
+                if (!grid) {
+                    return;
+                }
+
+                grid.setAttribute('aria-busy', 'true');
+
+                try {
+                    const response = await fetch('/api/intickets-events', { cache: 'no-store' });
+                    if (!response.ok) {
+                        throw new Error(`Request failed with status ${response.status}`);
+                    }
+
+                    const payload = await response.json();
+                    const list = Array.isArray(payload?.events) ? payload.events : [];
+
+                    if (!list.length) {
+                        throw new Error('Empty Intickets feed');
+                    }
+
+                    events = list.map(normalizeAfishaEvent);
+                    fallbackUsed = false;
+                } catch (error) {
+                    console.warn('Не удалось загрузить афишу Intickets, используем резервный список.', error);
+                    events = afishaFallbackEvents.map(normalizeAfishaEvent);
+                    fallbackUsed = true;
+                }
+
+                renderAfisha();
+            }
+
+            function renderAfisha() {
+                if (!grid) {
+                    return;
+                }
+
+                const term = (searchField?.value || '').trim().toLowerCase();
+                const sortValue = sortField?.value || 'date_asc';
+
+                const filtered = events.filter((event) => {
+                    const haystack = `${event.title} ${event.venue}`.toLowerCase();
+                    return haystack.includes(term);
+                });
+
+                filtered.sort((a, b) => {
+                    const aTime = a.date ? a.date.getTime() : 0;
+                    const bTime = b.date ? b.date.getTime() : 0;
+                    return sortValue === 'date_desc' ? bTime - aTime : aTime - bTime;
+                });
+
+                if (filtered.length) {
+                    grid.innerHTML = filtered.map(renderAfishaCard).join('');
+                } else {
+                    grid.innerHTML = '';
+                }
+
+                grid.setAttribute('aria-busy', 'false');
+
+                if (empty) {
+                    if (filtered.length > 0) {
+                        empty.hidden = true;
+                    } else {
+                        empty.hidden = false;
+                        empty.textContent = term ? 'По вашему запросу ничего не найдено.' : 'События не найдены.';
+                    }
+                }
+
+                if (statusField) {
+                    if (fallbackUsed) {
+                        statusField.hidden = false;
+                        statusField.textContent = 'Показаны события из резервного списка — проверьте подключение к Intickets.';
+                    } else {
+                        statusField.hidden = true;
+                        statusField.textContent = '';
+                    }
+                }
+            }
+        }
+
+        function normalizeAfishaEvent(raw) {
+            if (!raw) {
+                return {
+                    id: 'unknown',
+                    title: 'Без названия',
+                    venue: '',
+                    date: null,
+                    dateText: 'Дата уточняется',
+                    image: AFISHA_PLACEHOLDER_IMAGE,
+                    ticketUrl: '#',
+                    detailsUrl: '#',
+                    url: '#'
+                };
+            }
+
+            const isoDate = raw.date || raw.datetime_start || raw.starts_at || raw.start_date || raw.seance_date;
+            const parsedDate = isoDate ? new Date(isoDate) : null;
+            const displayDate = parsedDate ? formatAfishaDate(parsedDate) : 'Дата уточняется';
+
+            const seanceDescriptor = createSeanceDescriptor(raw, isoDate);
+            const eventIdentifier =
+                raw.inticketsEventIdentifier ||
+                raw.event_identifier ||
+                raw.eventPath ||
+                raw.event_slug ||
+                (raw.inticketsEventId ? `node/${raw.inticketsEventId}` : null) ||
+                (raw.event_id ? `node/${raw.event_id}` : null);
+
+            const detailsCandidate =
+                raw.detailsUrl ||
+                raw.details_url ||
+                raw.event_url ||
+                raw.url ||
+                raw.link ||
+                eventIdentifier;
+
+            const ticketCandidate =
+                raw.ticketUrl ||
+                raw.ticket_url ||
+                raw.seance_url ||
+                raw.url ||
+                raw.link ||
+                eventIdentifier;
+
+            const ticketUrl =
+                typeof raw.ticketUrl === 'string' && raw.ticketUrl
+                    ? raw.ticketUrl
+                    : seanceDescriptor?.directUrl
+                    ? composeInticketsUrl(seanceDescriptor.directUrl, { anchor: true })
+                    : composeInticketsUrl(ticketCandidate, { seance: seanceDescriptor, anchor: true });
+
+            const detailsUrl =
+                typeof raw.detailsUrl === 'string' && raw.detailsUrl
+                    ? composeInticketsUrl(raw.detailsUrl, { anchor: true })
+                    : composeInticketsUrl(detailsCandidate, { anchor: true });
+
+            const imageSource =
+                raw.image ||
+                raw.poster ||
+                raw.cover ||
+                raw.imageUrl ||
+                raw.photo ||
+                (Array.isArray(raw.photos) ? raw.photos[0]?.url : null) ||
+                AFISHA_PLACEHOLDER_IMAGE;
+
+            return {
+                id: raw.id || raw.event_id || raw.slug || 'unknown',
+                title: raw.title || raw.name || 'Без названия',
+                venue: raw.venue || raw.place || raw.location || '',
+                date: parsedDate instanceof Date && !Number.isNaN(parsedDate.getTime()) ? parsedDate : null,
+                dateText: displayDate,
+                image: imageSource || AFISHA_PLACEHOLDER_IMAGE,
+                ticketUrl: ticketUrl || '#',
+                detailsUrl: detailsUrl || '#',
+                url: (detailsUrl || ticketUrl || '#')
+            };
+        }
+
+        function renderAfishaCard(event) {
+            const safeTitle = escapeHtml(event.title);
+            const safeAlt = escapeAttr(`Афиша спектакля ${event.title}`);
+            const dateLabel = escapeHtml(event.dateText || 'Дата уточняется');
+            const venueLabel = event.venue ? ` · ${escapeHtml(event.venue)}` : '';
+            const cover = escapeAttr(event.image || AFISHA_PLACEHOLDER_IMAGE);
+            const ticketLink = escapeAttr(event.ticketUrl || event.url || '#');
+            const detailsLink = escapeAttr(event.detailsUrl || event.url || '#');
+
+            return `
+                <article class="afisha-card">
+                    <div class="afisha-card-cover">
+                        <img src="${cover}" alt="${safeAlt}" loading="lazy">
+                    </div>
+                    <div class="afisha-card-body">
+                        <h3 class="afisha-card-title">${safeTitle}</h3>
+                        <div class="afisha-card-meta">${dateLabel}${venueLabel}</div>
+                        <div class="afisha-card-actions">
+                            <a class="btn" href="${ticketLink}" target="_blank" rel="noopener">Купить билет</a>
+                            <a class="btn btn-ghost" href="${detailsLink}" target="_blank" rel="noopener">Подробнее</a>
+                        </div>
+                    </div>
+                </article>
+            `;
+        }
+
+        function renderAfishaSkeleton(grid, count) {
+            if (!grid) {
+                return;
+            }
+
+            const skeleton = `
+                <article class="afisha-card afisha-card--skeleton">
+                    <div class="afisha-card-cover"></div>
+                    <div class="afisha-card-body">
+                        <h3 class="afisha-card-title">Загрузка…</h3>
+                        <div class="afisha-card-meta">Скоро появится событие</div>
+                        <div class="afisha-card-actions">
+                            <span class="btn">&nbsp;</span>
+                            <span class="btn btn-ghost">&nbsp;</span>
+                        </div>
+                    </div>
+                </article>
+            `;
+
+            grid.innerHTML = Array.from({ length: count }, () => skeleton).join('');
+        }
+
+        function formatInticketsScheduleSuffix(date) {
+            if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+                return '';
+            }
+
+            const pad = (value) => String(value).padStart(2, '0');
+
+            return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}_${pad(date.getHours())}${pad(
+                date.getMinutes()
+            )}`;
+        }
+
+        function createSeanceDescriptor(raw, isoDate) {
+            const descriptor = {};
+
+            if (isoDate) {
+                descriptor.datetime = isoDate;
+            }
+
+            const seanceId =
+                raw?.inticketsSeanceId ??
+                raw?.seanceId ??
+                raw?.seance_id ??
+                raw?.session_id ??
+                (raw?.seance && raw.seance.id) ??
+                null;
+
+            if (seanceId) {
+                descriptor.seanceId = String(seanceId).trim();
+            }
+
+            const directUrl = raw?.seanceUrl ?? raw?.seance_url ?? null;
+            if (directUrl) {
+                descriptor.directUrl = directUrl;
+            }
+
+            return Object.keys(descriptor).length ? descriptor : null;
+        }
+
+        function formatAfishaDate(date) {
+            try {
+                return date.toLocaleString('ru-RU', {
+                    day: '2-digit',
+                    month: 'long',
+                    hour: '2-digit',
+                    minute: '2-digit'
+                });
+            } catch (error) {
+                console.warn('Не удалось отформатировать дату события', error);
+                return 'Дата уточняется';
+            }
+        }
+
+        function escapeHtml(value) {
+            const map = {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            };
+
+            return String(value ?? '').replace(/[&<>"']/g, (char) => map[char]);
+        }
+
+        function escapeAttr(value) {
+            return escapeHtml(value);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add the Intickets button stylesheet to the head so ticket widgets share the expected base styles
- introduce a central Intickets configuration, repertoire fixtures, and helper utilities to build automated ticket/detail links
- update the Afisha normaliser and rendering logic to use the generated ticket/detail URLs while preserving graceful fallbacks

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0230de92c8322b23249558a188df3