### PR TITLE
Drive hero banner and afisha actions from schedule

### DIFF
--- a/api/intickets-events.js
+++ b/api/intickets-events.js
@@ -1,0 +1,77 @@
+const DEFAULT_CACHE_SECONDS = 60;
+
+function buildResponse(res, statusCode, payload) {
+    if (typeof res.status === 'function') {
+        res.status(statusCode);
+    } else {
+        res.statusCode = statusCode;
+    }
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    const cacheControl = statusCode >= 400 ? 'no-store' : `public, max-age=${DEFAULT_CACHE_SECONDS}`;
+    res.setHeader('Cache-Control', cacheControl);
+    res.end(JSON.stringify(payload));
+}
+
+export default async function handler(req, res) {
+    const apiUrl = process.env.INTICKETS_EVENTS_URL;
+    const token = process.env.INTICKETS_TOKEN;
+
+    if (!apiUrl) {
+        return buildResponse(res, 500, {
+            error: 'Configuration error',
+            detail: 'INTICKETS_EVENTS_URL environment variable is not set.'
+        });
+    }
+
+    try {
+        const headers = { Accept: 'application/json' };
+        if (token) {
+            headers.Authorization = `Bearer ${token}`;
+        }
+
+        const upstreamResponse = await fetch(apiUrl, { headers });
+
+        if (!upstreamResponse.ok) {
+            const detail = await upstreamResponse.text();
+            return buildResponse(res, upstreamResponse.status, {
+                error: `Upstream error ${upstreamResponse.status}`,
+                detail
+            });
+        }
+
+        const payload = await upstreamResponse.json();
+        const events = normaliseEvents(payload);
+
+        return buildResponse(res, 200, { events });
+    } catch (error) {
+        return buildResponse(res, 500, {
+            error: 'Proxy failed',
+            detail: error instanceof Error ? error.message : String(error)
+        });
+    }
+}
+
+function normaliseEvents(payload) {
+    const items = Array.isArray(payload)
+        ? payload
+        : Array.isArray(payload?.events)
+        ? payload.events
+        : Array.isArray(payload?.data)
+        ? payload.data
+        : [];
+
+    return items.map((event) => ({
+        id: event?.id ?? event?.event_id ?? event?.slug ?? null,
+        title: event?.title ?? event?.name ?? 'Без названия',
+        date: event?.date ?? event?.datetime_start ?? event?.starts_at ?? event?.start_date ?? null,
+        venue: event?.venue?.name ?? event?.venue ?? event?.place ?? event?.location ?? '',
+        image:
+            event?.image?.url ??
+            event?.image ??
+            event?.poster ??
+            event?.cover ??
+            event?.photos?.[0]?.url ??
+            null,
+        url: event?.url ?? event?.seance_url ?? event?.link ?? null
+    }));
+}

--- a/baza_afisha.json
+++ b/baza_afisha.json
@@ -1,0 +1,28 @@
+{
+  "events": [
+    {
+      "id": "marat",
+      "title": "Мой бедный Марат",
+      "date": "2024-04-12",
+      "time": "19:00",
+      "link": "https://iframeab-pre2514.intickets.ru/seance/60835614/#abiframe",
+      "venue": "Москва · Сцена AmmA Production"
+    },
+    {
+      "id": "okna",
+      "title": "Окна. Город. Любовь...",
+      "date": "2024-04-26",
+      "time": "19:00",
+      "link": "https://iframeab-pre2514.intickets.ru/event/11756122/#abiframe",
+      "venue": "Москва · Арт-пространство «Окна»"
+    },
+    {
+      "id": "ostrov",
+      "title": "Остров",
+      "date": "2024-05-14",
+      "time": "19:00",
+      "link": "https://iframeab-pre2514.intickets.ru/events/#abiframe",
+      "venue": "Санкт-Петербург · Лофт «Остров»"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1321 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AmmA Production — продюсерский центр</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;700&family=Montserrat:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="//s3.intickets.ru/intickets.min.css">
+    <link rel="stylesheet" href="//s3.intickets.ru/intickets-button-simple.min.css">
+    <script src="//s3.intickets.ru/intickets.js"></script>
+    <style>
+        :root {
+            --background: #0f0f0f;
+            --background-alt: #171717;
+            --text: #f7f7f7;
+            --muted: #cfcfcf;
+            --accent: #d8b25d;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Montserrat', 'Segoe UI', Tahoma, sans-serif;
+            background: var(--background);
+            color: var(--text);
+            line-height: 1.6;
+        }
+
+        a {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        header {
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            background: rgba(12, 12, 12, 0.95);
+            backdrop-filter: blur(8px);
+            border-bottom: 1px solid rgba(216, 178, 93, 0.3);
+        }
+
+        .nav-container {
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 1rem 1.5rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1.5rem;
+        }
+
+        .logo {
+            font-weight: 700;
+            letter-spacing: 0.15em;
+            text-transform: uppercase;
+            font-size: 1.1rem;
+        }
+
+        nav ul {
+            list-style: none;
+            display: flex;
+            gap: 1.25rem;
+            margin: 0;
+            padding: 0;
+        }
+
+        nav a {
+            font-size: 0.95rem;
+            color: var(--muted);
+            position: relative;
+            transition: color 0.3s ease;
+        }
+
+        nav a::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: -0.35rem;
+            width: 100%;
+            height: 2px;
+            background: var(--accent);
+            transform: scaleX(0);
+            transform-origin: right;
+            transition: transform 0.3s ease;
+        }
+
+        nav a:hover {
+            color: var(--text);
+        }
+
+        nav a:hover::after {
+            transform: scaleX(1);
+            transform-origin: left;
+        }
+
+        main {
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 0 1.5rem 4rem;
+        }
+
+        .hero {
+            position: relative;
+            padding: 2.5rem 0 4.5rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+            gap: 2rem;
+        }
+
+        .hero-heading {
+            margin: 0;
+            display: inline-flex;
+            flex-direction: column;
+            gap: 0.6rem;
+            font-family: 'Cinzel', serif;
+            font-weight: 400;
+            letter-spacing: 0.2em;
+            align-items: center;
+            text-align: center;
+        }
+
+        .hero-brand {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.35em;
+            font-size: clamp(3.4rem, 7vw, 5.4rem);
+            line-height: 0.95;
+            text-transform: uppercase;
+        }
+
+        .hero-letter {
+            display: inline-block;
+        }
+
+        .hero-letter-large {
+            font-size: 1em;
+        }
+
+        .hero-letter-small {
+            font-size: 0.72em;
+            letter-spacing: 0.2em;
+        }
+
+        .hero-production {
+            font-size: clamp(1.2rem, 3vw, 1.9rem);
+            letter-spacing: 0.75em;
+            text-transform: uppercase;
+            padding-top: 0.75rem;
+            border-top: 1px solid rgba(247, 247, 247, 0.25);
+        }
+
+        .hero-director {
+            margin-top: 1.4rem;
+            display: inline-flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.4rem;
+            color: var(--accent);
+            text-transform: uppercase;
+            letter-spacing: 0.18em;
+            font-weight: 600;
+        }
+
+        .hero-director-label {
+            font-size: 0.7rem;
+            color: var(--accent);
+        }
+
+        .hero-director-name {
+            font-size: 0.95rem;
+            letter-spacing: 0.25em;
+            color: var(--accent);
+            margin-top: 0.4rem;
+        }
+
+        .hero p {
+            max-width: 640px;
+            color: var(--muted);
+            margin: 0 auto;
+        }
+
+        .banner {
+            width: 100%;
+            max-width: 960px;
+            margin: 0 auto;
+            border: 1px solid rgba(216, 178, 93, 0.4);
+            border-radius: 24px;
+            overflow: hidden;
+            position: relative;
+            min-height: 320px;
+            background: var(--background-alt);
+        }
+
+        .banner-item {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            text-align: center;
+            padding: 3rem 2rem;
+            gap: 1.4rem;
+            opacity: 0;
+            visibility: hidden;
+            pointer-events: none;
+            transform: translateY(18px);
+            transition: opacity 0.9s ease, transform 0.9s ease;
+            color: var(--text);
+            isolate: isolate;
+        }
+
+        .banner-item::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background:
+                linear-gradient(120deg, rgba(12, 12, 12, 0.78), rgba(12, 12, 12, 0.55)),
+                var(--slide-bg, radial-gradient(circle at top, rgba(216,178,93,0.2), transparent 70%));
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
+            z-index: -2;
+            transition: transform 1.2s ease;
+        }
+
+        .banner-item::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(180deg, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.55));
+            z-index: -1;
+        }
+
+        .banner-item.is-active {
+            opacity: 1;
+            visibility: visible;
+            pointer-events: auto;
+            transform: translateY(0);
+        }
+
+        .banner-item.is-active::before {
+            transform: scale(1.04);
+        }
+
+        .banner-item-brand {
+            gap: 1.6rem;
+            --slide-bg: radial-gradient(circle at 20% 20%, rgba(216, 178, 93, 0.35), transparent 60%),
+                         linear-gradient(135deg, rgba(255,255,255,0.05), rgba(0,0,0,0.85));
+        }
+
+        .banner-title {
+            font-size: clamp(1.8rem, 4vw, 2.8rem);
+            font-weight: 700;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        .banner-date {
+            font-size: 0.85rem;
+            letter-spacing: 0.28em;
+            text-transform: uppercase;
+            padding: 0.55rem 1.6rem;
+            border-radius: 999px;
+            border: 1px solid rgba(216, 178, 93, 0.65);
+            background: rgba(12, 12, 12, 0.55);
+            color: var(--accent);
+        }
+
+        .banner-cta {
+            padding: 0.85rem 2.5rem;
+            border-radius: 999px;
+            border: 1px solid rgba(216, 178, 93, 0.7);
+            color: var(--background);
+            background: var(--accent);
+            font-weight: 600;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .banner-cta:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 10px 25px rgba(216, 178, 93, 0.2);
+        }
+
+        .banner-cta--disabled {
+            pointer-events: none;
+            background: transparent;
+            color: var(--muted);
+            border-style: dashed;
+            cursor: default;
+        }
+
+        section {
+            margin-top: 5rem;
+        }
+
+        .section-title {
+            font-size: clamp(1.8rem, 3vw, 2.4rem);
+            margin-bottom: 1.5rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+        }
+
+        .about {
+            display: grid;
+            gap: 2rem;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            background: linear-gradient(145deg, rgba(255,255,255,0.03), rgba(0,0,0,0));
+            border-radius: 20px;
+            padding: 2.5rem;
+            border: 1px solid rgba(216, 178, 93, 0.2);
+        }
+
+        .about p {
+            margin: 0;
+            color: var(--muted);
+        }
+
+        .widget {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            padding: 2rem;
+            border-radius: 18px;
+            border: 1px solid rgba(216, 178, 93, 0.2);
+            background: var(--background-alt);
+        }
+
+        .widget a {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.9rem 1.8rem;
+            border-radius: 999px;
+            background: transparent;
+            border: 1px solid var(--accent);
+            color: var(--accent);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-weight: 600;
+            transition: background 0.3s ease, color 0.3s ease;
+        }
+
+        .widget a:hover {
+            background: var(--accent);
+            color: var(--background);
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 999px;
+            padding: 0.75rem 1.25rem;
+            font-size: 0.88rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-weight: 600;
+            background: var(--accent);
+            border: 1px solid rgba(216, 178, 93, 0.8);
+            color: var(--background);
+            text-decoration: none;
+            transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
+            cursor: pointer;
+        }
+
+        .btn:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 12px 24px rgba(216, 178, 93, 0.25);
+        }
+
+        .btn:focus-visible {
+            outline: 2px solid rgba(216, 178, 93, 0.75);
+            outline-offset: 2px;
+        }
+
+        .afisha {
+            margin-top: 4rem;
+            padding: 3rem;
+            border-radius: 24px;
+            border: 1px solid rgba(216, 178, 93, 0.18);
+            background: linear-gradient(145deg, rgba(255, 255, 255, 0.02), rgba(0, 0, 0, 0));
+            display: flex;
+            flex-direction: column;
+            gap: 1.8rem;
+        }
+
+        .afisha-header {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1.25rem;
+        }
+
+        .afisha-description {
+            margin: 0;
+            max-width: 560px;
+            color: var(--muted);
+        }
+
+        .afisha-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
+
+        .afisha-field {
+            position: relative;
+            flex: 1 1 220px;
+        }
+
+        .afisha-field input,
+        .afisha-field select {
+            width: 100%;
+            padding: 0.85rem 1.1rem;
+            border-radius: 14px;
+            border: 1px solid rgba(216, 178, 93, 0.28);
+            background: rgba(17, 17, 17, 0.92);
+            color: var(--text);
+            font-size: 0.95rem;
+            letter-spacing: 0.03em;
+        }
+
+        .afisha-status {
+            padding: 0.75rem 1rem;
+            border-radius: 14px;
+            border: 1px solid rgba(216, 178, 93, 0.28);
+            background: rgba(216, 178, 93, 0.1);
+            color: var(--accent);
+            font-size: 0.9rem;
+        }
+
+        .afisha-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .afisha-card {
+            display: flex;
+            flex-direction: column;
+            border-radius: 20px;
+            border: 1px solid rgba(216, 178, 93, 0.18);
+            background: linear-gradient(160deg, rgba(255, 255, 255, 0.02), rgba(0, 0, 0, 0.65));
+            overflow: hidden;
+            min-height: 100%;
+            transition: transform 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+        }
+
+        .afisha-card:hover {
+            transform: translateY(-4px);
+            border-color: rgba(216, 178, 93, 0.45);
+            box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
+        }
+
+        .afisha-card-cover {
+            position: relative;
+            width: 100%;
+            aspect-ratio: 16 / 10;
+            background: rgba(15, 15, 15, 0.72);
+            overflow: hidden;
+            border: none;
+            padding: 0;
+            display: block;
+            cursor: pointer;
+        }
+
+        .afisha-card-cover img {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            transition: transform 0.4s ease;
+        }
+
+        .afisha-card-cover::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(160deg, rgba(216, 178, 93, 0.08), rgba(0, 0, 0, 0.55));
+            opacity: 0;
+            transition: opacity 0.35s ease;
+        }
+
+        .afisha-card:hover .afisha-card-cover img,
+        .afisha-card-cover:focus-visible img {
+            transform: scale(1.05);
+        }
+
+        .afisha-card:hover .afisha-card-cover::after,
+        .afisha-card-cover:focus-visible::after {
+            opacity: 1;
+        }
+
+        .afisha-card-cover:focus-visible {
+            outline: none;
+            box-shadow: inset 0 0 0 2px rgba(216, 178, 93, 0.6);
+        }
+
+        .afisha-card-body {
+            display: flex;
+            flex-direction: column;
+            gap: 0.85rem;
+            padding: 1.6rem 1.6rem 1.8rem;
+            flex: 1;
+            min-height: 220px;
+        }
+
+        .afisha-card-title {
+            margin: 0;
+            font-size: 1rem;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .afisha-card-meta {
+            color: var(--muted);
+            font-size: 0.92rem;
+            letter-spacing: 0.04em;
+        }
+
+        .afisha-card-actions {
+            margin-top: auto;
+            display: flex;
+            align-items: stretch;
+        }
+
+        .afisha-card-actions > * {
+            flex: 1;
+            min-height: 3rem;
+        }
+
+        .afisha-card-actions .btn {
+            width: 100%;
+        }
+
+        .afisha-card-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.75rem 1.25rem;
+            border-radius: 999px;
+            border: 1px dashed rgba(216, 178, 93, 0.6);
+            background: rgba(216, 178, 93, 0.08);
+            color: var(--muted);
+            font-size: 0.82rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .afisha-empty {
+            padding: 1.6rem;
+            border-radius: 18px;
+            border: 1px dashed rgba(216, 178, 93, 0.4);
+            text-align: center;
+            color: var(--muted);
+            letter-spacing: 0.05em;
+        }
+
+        .afisha-card.afisha-card--skeleton {
+            position: relative;
+            overflow: hidden;
+        }
+
+        .afisha-card.afisha-card--skeleton::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(120deg, rgba(247, 247, 247, 0), rgba(247, 247, 247, 0.12), rgba(247, 247, 247, 0));
+            animation: shimmer 1.6s infinite;
+        }
+
+        .afisha-card.afisha-card--skeleton * {
+            visibility: hidden;
+        }
+
+        .afisha-modal {
+            position: fixed;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            padding: 2.5rem 1.5rem;
+            background: rgba(10, 10, 10, 0.72);
+            backdrop-filter: blur(12px);
+            z-index: 250;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.35s ease;
+        }
+
+        .afisha-modal.is-visible {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        .afisha-modal-dialog {
+            position: relative;
+            width: min(100%, 780px);
+            border-radius: 24px;
+            border: 1px solid rgba(216, 178, 93, 0.4);
+            background: linear-gradient(160deg, rgba(26, 26, 26, 0.95), rgba(0, 0, 0, 0.86));
+            padding: 2.25rem 2.5rem 2.5rem;
+            box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55);
+            display: flex;
+            flex-direction: column;
+            gap: 1.2rem;
+            transform: translateY(40px) scale(0.96);
+            opacity: 0;
+            transition: transform 0.45s ease, opacity 0.45s ease;
+        }
+
+        .afisha-modal.is-visible .afisha-modal-dialog {
+            transform: translateY(0) scale(1);
+            opacity: 1;
+        }
+
+        .afisha-modal-close {
+            position: absolute;
+            top: 1.2rem;
+            right: 1.2rem;
+            width: 42px;
+            height: 42px;
+            border-radius: 999px;
+            border: 1px solid rgba(216, 178, 93, 0.45);
+            background: rgba(216, 178, 93, 0.12);
+            color: var(--accent);
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.4rem;
+            cursor: pointer;
+            transition: background 0.3s ease, transform 0.3s ease, border-color 0.3s ease;
+        }
+
+        .afisha-modal-close:hover {
+            transform: translateY(-2px);
+            border-color: rgba(216, 178, 93, 0.75);
+        }
+
+        .afisha-modal-close:focus-visible {
+            outline: 2px solid rgba(216, 178, 93, 0.8);
+            outline-offset: 2px;
+        }
+
+        .afisha-modal-header {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .afisha-modal-title {
+            margin: 0;
+            font-size: clamp(1.6rem, 3vw, 2.1rem);
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+        }
+
+        .afisha-modal-meta {
+            color: var(--accent);
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            font-size: 0.85rem;
+        }
+
+        .afisha-modal-description {
+            margin: 0;
+            color: var(--muted);
+            font-size: 0.98rem;
+        }
+
+        .afisha-modal-creators {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: grid;
+            gap: 0.45rem;
+        }
+
+        .afisha-modal-creators li {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem 0.75rem;
+            color: var(--text);
+        }
+
+        .afisha-modal-role {
+            font-weight: 600;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: var(--accent);
+        }
+
+        .afisha-modal-name {
+            color: var(--muted);
+        }
+
+        .afisha-modal-gallery {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 0.75rem;
+        }
+
+        .afisha-modal-gallery figure {
+            margin: 0;
+            position: relative;
+            border-radius: 14px;
+            overflow: hidden;
+            background: rgba(17, 17, 17, 0.8);
+        }
+
+        .afisha-modal-gallery img {
+            display: block;
+            width: 100%;
+            height: 140px;
+            object-fit: cover;
+        }
+
+        .afisha-modal-gallery figcaption {
+            position: absolute;
+            inset: auto 0 0 0;
+            padding: 0.35rem 0.75rem;
+            background: linear-gradient(180deg, rgba(15, 15, 15, 0), rgba(15, 15, 15, 0.75));
+            font-size: 0.68rem;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            color: rgba(247, 247, 247, 0.85);
+        }
+
+        .afisha-modal .btn {
+            align-self: flex-start;
+            padding-inline: 1.6rem;
+        }
+
+        .visually-hidden {
+            position: absolute !important;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
+        @keyframes shimmer {
+            0% {
+                transform: translateX(-100%);
+            }
+            100% {
+                transform: translateX(100%);
+            }
+        }
+
+        .repertoire-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .repertoire-card {
+            padding: 1.75rem;
+            border-radius: 18px;
+            background: linear-gradient(160deg, rgba(255,255,255,0.05), rgba(0,0,0,0.8));
+            border: 1px solid rgba(216, 178, 93, 0.2);
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .repertoire-media {
+            width: 100%;
+            aspect-ratio: 4 / 3;
+            border-radius: 14px;
+            overflow: hidden;
+            background: rgba(247, 247, 247, 0.08);
+        }
+
+        .repertoire-media svg {
+            width: 100%;
+            height: 100%;
+            display: block;
+        }
+
+        .repertoire-card span {
+            text-transform: uppercase;
+            font-size: 0.8rem;
+            letter-spacing: 0.3em;
+            color: var(--accent);
+        }
+
+        .repertoire-card h3 {
+            margin: 0;
+        }
+
+        .repertoire-card p {
+            margin: 0;
+            color: var(--muted);
+        }
+
+        .team-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 1.25rem;
+        }
+
+        .team-card {
+            border: 1px solid rgba(216, 178, 93, 0.2);
+            border-radius: 18px;
+            padding: 1.8rem;
+            background: var(--background-alt);
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .team-card strong {
+            letter-spacing: 0.05em;
+            font-size: 1.1rem;
+        }
+
+        .team-card span {
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .contacts {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 2rem;
+            padding: 2.5rem;
+            border: 1px solid rgba(216, 178, 93, 0.2);
+            border-radius: 20px;
+            background: linear-gradient(145deg, rgba(216, 178, 93, 0.12), rgba(0,0,0,0.75));
+        }
+
+        .contact-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .contact-info a {
+            color: var(--accent);
+        }
+
+        .social-buttons {
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .social-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.75rem 1.4rem;
+            border-radius: 999px;
+            border: 1px solid rgba(216, 178, 93, 0.5);
+            color: var(--text);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            font-size: 0.85rem;
+            transition: transform 0.3s ease, background 0.3s ease;
+        }
+
+        .social-button svg {
+            width: 18px;
+            height: 18px;
+            fill: currentColor;
+        }
+
+        .social-button:hover {
+            transform: translateY(-3px);
+            background: rgba(216, 178, 93, 0.15);
+        }
+
+        footer {
+            margin-top: 4rem;
+            padding: 2rem 1.5rem;
+            text-align: center;
+            color: var(--muted);
+            border-top: 1px solid rgba(216, 178, 93, 0.2);
+        }
+
+        @media (max-width: 768px) {
+            nav ul {
+                display: none;
+            }
+
+            header {
+                position: static;
+            }
+
+            .hero {
+                padding: 2.4rem 0 3.2rem;
+            }
+
+            .hero-brand {
+                gap: 0.25em;
+                flex-wrap: wrap;
+            }
+
+            .hero-director {
+                letter-spacing: 0.14em;
+            }
+
+            .banner {
+                border-radius: 16px;
+                min-height: 280px;
+            }
+
+            .banner-item {
+                padding: 2.4rem 1.6rem;
+            }
+
+            .afisha {
+                padding: 2.4rem 2rem;
+                gap: 1.6rem;
+            }
+
+            .afisha-header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 0.75rem;
+            }
+
+            .afisha-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .afisha-card-body {
+                padding: 1.4rem 1.4rem 1.6rem;
+                min-height: 200px;
+            }
+
+            .afisha-card-title {
+                font-size: 0.95rem;
+                letter-spacing: 0.05em;
+            }
+
+            .afisha-modal {
+                padding: 2rem 1.25rem;
+            }
+
+            .afisha-modal-dialog {
+                padding: 1.85rem 1.8rem 2.1rem;
+            }
+
+            .afisha-modal-gallery img {
+                height: 120px;
+            }
+
+            .repertoire-card {
+                padding: 1.5rem;
+            }
+        }
+
+        @media (max-width: 560px) {
+            main {
+                padding: 0 1rem 3.5rem;
+            }
+
+            .hero-brand {
+                font-size: clamp(2.4rem, 14vw, 3.2rem);
+                letter-spacing: 0.12em;
+            }
+
+            .hero-production {
+                letter-spacing: 0.45em;
+                font-size: clamp(1rem, 6vw, 1.35rem);
+            }
+
+            .hero-director-name {
+                letter-spacing: 0.18em;
+            }
+
+            .banner {
+                min-height: 250px;
+            }
+
+            .banner-item {
+                padding: 2rem 1.25rem;
+            }
+
+            .banner-title {
+                font-size: clamp(1.5rem, 6vw, 2.1rem);
+            }
+
+            .banner-date {
+                font-size: 0.72rem;
+                letter-spacing: 0.18em;
+                padding: 0.45rem 1.2rem;
+            }
+
+            .afisha {
+                padding: 1.8rem 1.2rem;
+                gap: 1.4rem;
+            }
+
+            .afisha-card-body {
+                padding: 1.25rem 1.25rem 1.4rem;
+                min-height: 190px;
+            }
+
+            .afisha-card-title {
+                font-size: 0.92rem;
+            }
+
+            .afisha-card-meta {
+                font-size: 0.88rem;
+            }
+
+            .afisha-modal-dialog {
+                padding: 1.6rem 1.35rem 1.8rem;
+            }
+
+            .afisha-modal-close {
+                top: 0.75rem;
+                right: 0.75rem;
+            }
+
+            .afisha-modal-gallery {
+                grid-template-columns: 1fr;
+            }
+
+            .afisha-modal-gallery img {
+                height: 160px;
+            }
+
+            .repertoire-media {
+                aspect-ratio: 3 / 2;
+            }
+
+            .contacts {
+                padding: 1.8rem;
+            }
+
+            .social-buttons {
+                gap: 0.75rem;
+            }
+        }
+
+    </style>
+</head>
+<body>
+    <header>
+        <div class="nav-container">
+            <div class="logo">AmmA Production</div>
+            <nav>
+                <ul>
+                    <li><a href="#about">О центре</a></li>
+                    <li><a href="#repertoire">Репертуар</a></li>
+                    <li><a href="#team">Команда</a></li>
+                    <li><a href="#contacts">Контакты</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero" id="about">
+            <div class="banner hero-slider" aria-label="Анимированный баннер AmmA Production">
+                <div class="banner-item banner-item-brand is-active" data-hero-brand>
+                    <h1 class="hero-heading" aria-label="AmmA Production">
+                        <span class="hero-brand" aria-hidden="true">
+                            <span class="hero-letter hero-letter-large">A</span>
+                            <span class="hero-letter hero-letter-small">M</span>
+                            <span class="hero-letter hero-letter-small">M</span>
+                            <span class="hero-letter hero-letter-large">A</span>
+                        </span>
+                        <span class="hero-production" aria-hidden="true">PRODUCTION</span>
+                    </h1>
+                    <div class="hero-director" aria-label="Художественный руководитель — Вера Анненкова">
+                        <span class="hero-director-label">Художественный руководитель</span>
+                        <span class="hero-director-name">Вера Анненкова</span>
+                    </div>
+                </div>
+            </div>
+            <p>Продюсерский центр нового поколения, объединяющий драматическое искусство, современный визуальный язык и авторские творческие решения. Мы создаём спектакли, которые говорят с публикой на одном языке и оставляют послевкусие настоящего театра.</p>
+        </section>
+
+        <section class="afisha" id="playbill" data-afisha>
+            <div class="afisha-header">
+                <h2 class="section-title">Афиша</h2>
+                <p class="afisha-description">Расписание спектаклей формируется автоматически из файла <strong>baza_afisha.json</strong>. Обновите дату, время или ссылку в базе — и афиша мгновенно изменится на сайте.</p>
+            </div>
+            <div class="afisha-controls">
+                <label class="afisha-field">
+                    <span class="visually-hidden">Поиск по названию спектакля</span>
+                    <input type="search" placeholder="Поиск по названию…" data-afisha-search autocomplete="off">
+                </label>
+                <label class="afisha-field">
+                    <span class="visually-hidden">Сортировка по дате события</span>
+                    <select data-afisha-sort>
+                        <option value="date_asc">Ближайшие сначала</option>
+                        <option value="date_desc">Дальние сначала</option>
+                    </select>
+                </label>
+            </div>
+            <div class="afisha-status" data-afisha-status hidden></div>
+            <div class="afisha-grid" data-afisha-grid aria-live="polite" aria-busy="true"></div>
+            <div class="afisha-empty" data-afisha-empty hidden>События не найдены.</div>
+        </section>
+        <div class="afisha-modal" data-afisha-modal hidden>
+            <div class="afisha-modal-dialog" data-afisha-modal-dialog role="dialog" aria-modal="true" aria-labelledby="afisha-modal-title" tabindex="-1">
+                <button type="button" class="afisha-modal-close" data-afisha-modal-close aria-label="Закрыть окно афиши">&times;</button>
+                <div class="afisha-modal-header">
+                    <h3 class="afisha-modal-title" id="afisha-modal-title"></h3>
+                    <div class="afisha-modal-meta" data-afisha-modal-meta></div>
+                </div>
+                <p class="afisha-modal-description" data-afisha-modal-description></p>
+                <ul class="afisha-modal-creators" data-afisha-modal-creators></ul>
+                <div class="afisha-modal-gallery" data-afisha-modal-gallery></div>
+                <a class="btn" data-afisha-modal-ticket target="_blank" rel="noopener">Купить билет</a>
+            </div>
+        </div>
+        <section>
+            <div class="about">
+                <div>
+                    <h2 class="section-title">О центре</h2>
+                    <p>AmmA Production сопровождает культурные проекты на всех этапах — от идеи до премьерного поклона. Наша команда курирует постановки, гастроли, медиасопровождение и работу с партнёрами, создавая актуальные театральные события.</p>
+                </div>
+                <div class="widget">
+                    <h3 style="margin:0; font-size:1.2rem; text-transform:uppercase; letter-spacing:0.08em;">Онлайн-билеты</h3>
+                    <p style="margin:0; color:var(--muted);">Используйте готовый виджет для моментальной покупки билетов на спектакли нашего репертуара.</p>
+                    <a href="https://iframeab-pre2514.intickets.ru/seance/60835614/#abiframe">Купить билет</a>
+                </div>
+            </div>
+        </section>
+
+        <section id="repertoire">
+            <h2 class="section-title">Текущий репертуар</h2>
+            <div class="repertoire-grid">
+                <div class="repertoire-card">
+                    <figure class="repertoire-media">
+                        <svg viewBox="0 0 320 240" role="img" aria-labelledby="poster-marat" xmlns="http://www.w3.org/2000/svg">
+                            <title id="poster-marat">Стилизованная афиша спектакля «Мой бедный Марат»</title>
+                            <defs>
+                                <linearGradient id="marat-bg" x1="0" y1="0" x2="1" y2="1">
+                                    <stop offset="0%" stop-color="#1c1c1c" />
+                                    <stop offset="100%" stop-color="#0b0b0b" />
+                                </linearGradient>
+                                <linearGradient id="marat-accent" x1="0" y1="0" x2="1" y2="1">
+                                    <stop offset="0%" stop-color="#d8b25d" />
+                                    <stop offset="100%" stop-color="#8f6a1f" />
+                                </linearGradient>
+                            </defs>
+                            <rect width="320" height="240" fill="url(#marat-bg)" />
+                            <g opacity="0.25" stroke="#f7f7f7" stroke-opacity="0.4" stroke-width="2">
+                                <line x1="28" y1="52" x2="292" y2="52" />
+                                <line x1="28" y1="118" x2="292" y2="118" />
+                                <line x1="28" y1="184" x2="292" y2="184" />
+                            </g>
+                            <path d="M36 212 L160 38 L284 212 Z" fill="url(#marat-accent)" fill-opacity="0.68" />
+                            <path d="M72 212 L160 108 L248 212 Z" fill="none" stroke="#d8b25d" stroke-width="4" stroke-opacity="0.7" />
+                            <circle cx="160" cy="126" r="26" fill="#0f0f0f" stroke="#d8b25d" stroke-width="3" />
+                            <path d="M126 212 L150 166 L170 212 Z" fill="#101010" opacity="0.85" />
+                            <path d="M176 212 L190 186 L204 212 Z" fill="#0b0b0b" opacity="0.75" />
+                        </svg>
+                    </figure>
+                    <span>Драма</span>
+                    <h3>Мой бедный Марат</h3>
+                    <p>Пьеса Алексея Арбузова о молодости, любви и надежде, которая не угасает даже в самые тяжёлые времена.</p>
+                </div>
+                <div class="repertoire-card">
+                    <figure class="repertoire-media">
+                        <svg viewBox="0 0 320 240" role="img" aria-labelledby="poster-okna" xmlns="http://www.w3.org/2000/svg">
+                            <title id="poster-okna">Стилизованная афиша спектакля «Окна. Город. Любовь...»</title>
+                            <defs>
+                                <linearGradient id="okna-bg" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#1e1e1e" />
+                                    <stop offset="100%" stop-color="#090909" />
+                                </linearGradient>
+                                <linearGradient id="okna-highlight" x1="0" y1="0" x2="1" y2="1">
+                                    <stop offset="0%" stop-color="#d8b25d" stop-opacity="0.9" />
+                                    <stop offset="100%" stop-color="#b48b3f" stop-opacity="0.6" />
+                                </linearGradient>
+                            </defs>
+                            <rect width="320" height="240" fill="url(#okna-bg)" />
+                            <g stroke="#f7f7f7" stroke-width="3" stroke-opacity="0.08">
+                                <line x1="40" y1="30" x2="280" y2="30" />
+                                <line x1="40" y1="90" x2="280" y2="90" />
+                                <line x1="40" y1="150" x2="280" y2="150" />
+                                <line x1="40" y1="210" x2="280" y2="210" />
+                                <line x1="40" y1="30" x2="40" y2="210" />
+                                <line x1="110" y1="30" x2="110" y2="210" />
+                                <line x1="190" y1="30" x2="190" y2="210" />
+                                <line x1="280" y1="30" x2="280" y2="210" />
+                            </g>
+                            <g fill="url(#okna-highlight)" fill-opacity="0.85">
+                                <rect x="56" y="48" width="40" height="60" rx="6" />
+                                <rect x="126" y="110" width="48" height="70" rx="6" />
+                                <rect x="206" y="60" width="52" height="82" rx="6" />
+                            </g>
+                            <g fill="#d8b25d" fill-opacity="0.4">
+                                <rect x="62" y="164" width="28" height="36" rx="4" />
+                                <rect x="138" y="70" width="26" height="32" rx="4" />
+                                <rect x="216" y="162" width="34" height="44" rx="4" />
+                            </g>
+                            <path d="M36 212 H284" stroke="#d8b25d" stroke-width="4" stroke-linecap="round" stroke-opacity="0.6" />
+                        </svg>
+                    </figure>
+                    <span>Поэтический спектакль</span>
+                    <h3>Окна. Город. Любовь...</h3>
+                    <p>Погружение в городские истории, рассказанные языком пластики, видеоарта и живой музыки.</p>
+                </div>
+                <div class="repertoire-card">
+                    <figure class="repertoire-media">
+                        <svg viewBox="0 0 320 240" role="img" aria-labelledby="poster-ostrov" xmlns="http://www.w3.org/2000/svg">
+                            <title id="poster-ostrov">Стилизованная афиша спектакля «Остров»</title>
+                            <defs>
+                                <linearGradient id="ostrov-sky" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#161616" />
+                                    <stop offset="100%" stop-color="#050505" />
+                                </linearGradient>
+                                <linearGradient id="ostrov-glow" x1="0" y1="0" x2="1" y2="1">
+                                    <stop offset="0%" stop-color="#d8b25d" stop-opacity="0.85" />
+                                    <stop offset="100%" stop-color="#8d6f2c" stop-opacity="0.6" />
+                                </linearGradient>
+                            </defs>
+                            <rect width="320" height="240" fill="url(#ostrov-sky)" />
+                            <circle cx="236" cy="64" r="34" fill="url(#ostrov-glow)" fill-opacity="0.75" />
+                            <path d="M0 188 Q80 144 160 176 T320 188 V240 H0 Z" fill="#0c0c0c" />
+                            <path d="M92 188 Q120 150 160 164 Q200 178 228 188 Z" fill="#111" />
+                            <path d="M128 186 Q160 148 188 184 Z" fill="#d8b25d" fill-opacity="0.45" />
+                            <g stroke="#d8b25d" stroke-width="3" stroke-opacity="0.6" fill="none">
+                                <path d="M40 212 C80 204 120 204 160 212" />
+                                <path d="M160 212 C200 220 240 220 280 212" />
+                            </g>
+                            <g stroke="#f7f7f7" stroke-opacity="0.12" stroke-width="2" fill="none">
+                                <path d="M24 138 Q112 96 160 120 Q208 144 296 108" />
+                            </g>
+                        </svg>
+                    </figure>
+                    <span>Современная притча</span>
+                    <h3>Остров</h3>
+                    <p>Постановка о поиске себя и силе одиночества, объединяющая перформанс, медиа и авторскую музыку.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="team">
+            <h2 class="section-title">Команда</h2>
+            <div class="team-grid">
+                <div class="team-card">
+                    <strong>Вера Анненкова</strong>
+                    <span>Художественный руководитель</span>
+                </div>
+                <div class="team-card">
+                    <strong>Михаил Маликов</strong>
+                    <span>Продюсер</span>
+                </div>
+                <div class="team-card">
+                    <strong>Алина Мазненкова</strong>
+                    <span>PR и коммуникации</span>
+                </div>
+                <div class="team-card">
+                    <strong>Максим Дементьев</strong>
+                    <span>Технический директор</span>
+                </div>
+                <div class="team-card">
+                    <strong>Аксинья Олейник</strong>
+                    <span>Куратор проектов</span>
+                </div>
+            </div>
+        </section>
+
+        <section id="contacts">
+            <h2 class="section-title">Контакты</h2>
+            <div class="contacts">
+                <div class="contact-info">
+                    <div><strong>Телефон:</strong> <a href="tel:+79991234567">+7 (999) 123-45-67</a></div>
+                    <div><strong>Email:</strong> <a href="mailto:info@amma-production.ru">info@amma-production.ru</a></div>
+                    <div><strong>Адрес:</strong> Москва, Большая театральная, 12</div>
+                    <div><strong>График:</strong> Пн–Пт 10:00–19:00</div>
+                </div>
+                <div>
+                    <h3 style="margin-top:0; text-transform:uppercase; letter-spacing:0.08em;">Свяжитесь с нами</h3>
+                    <p style="color:var(--muted); margin-top:0;">Менеджеры AmmA Production готовы помочь с организацией показов, партнёрскими предложениями и покупкой билетов.</p>
+                    <div class="social-buttons">
+                        <a class="social-button" href="https://wa.me/79991234567" target="_blank" rel="noopener">
+                            <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M16.04 3C9.4 3 4 8.29 4 14.82c0 2.48.79 4.79 2.14 6.69L4 29l7.74-2.06c1.83 1 3.94 1.57 6.3 1.57 6.63 0 12.04-5.29 12.04-11.82C30.09 8.29 22.67 3 16.04 3zm0 20.97c-2.03 0-3.92-.56-5.52-1.53l-.39-.24-4.59 1.22 1.23-4.35-.26-.45a9.43 9.43 0 01-1.45-4.99c0-5.3 4.42-9.62 9.98-9.62s9.98 4.32 9.98 9.62-4.42 9.62-9.98 9.62zm5.76-7.18c-.31-.15-1.84-.9-2.12-1-.28-.1-.49-.15-.7.15-.21.31-.81 1-.99 1.2-.18.21-.37.23-.68.08-.31-.16-1.29-.47-2.46-1.5-.91-.81-1.53-1.81-1.71-2.12-.18-.31-.02-.48.13-.63.14-.14.31-.37.47-.55.15-.18.21-.31.31-.52.1-.21.05-.39-.02-.55-.08-.15-.7-1.68-.96-2.3-.25-.6-.51-.52-.7-.53l-.6-.01c-.21 0-.55.08-.84.39-.28.31-1.1 1.08-1.1 2.63s1.13 3.06 1.29 3.27c.16.21 2.23 3.38 5.41 4.73.76.33 1.35.53 1.81.68.76.24 1.45.21 2 .13.61-.09 1.84-.75 2.1-1.48.26-.73.26-1.36.18-1.48-.08-.13-.28-.21-.6-.37z"></path></svg>
+                            WhatsApp
+                        </a>
+                        <a class="social-button" href="https://t.me/amma_production" target="_blank" rel="noopener">
+                            <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M28.44 5.23L3.46 14.97c-1.69.66-1.68 1.58-.31 2.02l6.21 1.94 2.39 7.64c.29.81.15 1.14.99 1.14.65 0 .94-.3 1.31-.65l3.15-3.06 6.56 4.83c1.2.66 2.07.32 2.37-1.11l4.29-20.13c.44-1.76-.67-2.55-1.98-2.03zM25.4 9.3l-11.2 10.4c-.49.44-.18.69.29 1.11l3.36 2.86c.56.52 1.14.16 1.31-.29l2.53-7.56 4.59-4.35c.23-.21-.05-.5-.88-.17z"></path></svg>
+                            Telegram
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        © 2024 AmmA Production. Все права защищены.
+    </footer>
+
+    <script src="main.js"></script>
+
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,709 @@
+'use strict';
+
+const BAZA_AFISHA_URL = 'baza_afisha.json';
+const AFISHA_PLACEHOLDER_IMAGE = 'https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=1200&q=80';
+const AFISHA_SUPPLEMENTAL = Object.freeze({
+    marat: {
+        title: 'Мой бедный Марат',
+        venue: 'Москва · Сцена AmmA Production',
+        image: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80',
+        description:
+            'Легендарная история Алексея Арбузова о трёх молодых людях, чья дружба и любовь взрослеют на фоне осаждённого города.',
+        creators: [
+            { role: 'Режиссёр', name: 'Вера Анненкова' },
+            { role: 'Продюсер', name: 'Михаил Маликов' },
+            { role: 'Исполнители', name: 'Алина Мазненкова, Максим Дементьев' },
+            { role: 'Художник по свету', name: 'Аксинья Олейник' }
+        ],
+        gallery: [
+            {
+                src: 'https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80',
+                caption: 'Погружение в атмосферу блокадного города'
+            },
+            {
+                src: 'https://images.unsplash.com/photo-1515169067865-5387ec356754?auto=format&fit=crop&w=900&q=80',
+                caption: 'Диалог героев на тёмной сцене'
+            },
+            {
+                src: 'https://images.unsplash.com/photo-1478720568477-152d9b164e26?auto=format&fit=crop&w=900&q=80',
+                caption: 'Финальный световой акцент спектакля'
+            }
+        ],
+        ticketUrl: 'https://iframeab-pre2514.intickets.ru/seance/60835614/#abiframe'
+    },
+    okna: {
+        title: 'Окна. Город. Любовь...',
+        venue: 'Москва · Арт-пространство «Окна»',
+        image: 'https://images.unsplash.com/photo-1514525253161-7a46d19cd819?auto=format&fit=crop&w=1200&q=80',
+        description:
+            'Поэтический спектакль о городских историях, где пластика, видеоарт и музыка превращают каждое окно в отдельную историю любви.',
+        creators: [
+            { role: 'Художественный руководитель', name: 'Вера Анненкова' },
+            { role: 'Продюсер', name: 'Михаил Маликов' },
+            { role: 'Видеохудожник', name: 'Аксинья Олейник' },
+            { role: 'Исполнители', name: 'Алина Мазненкова, Максим Дементьев' }
+        ],
+        gallery: [
+            {
+                src: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80',
+                caption: 'Городской ритм спектакля'
+            },
+            {
+                src: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80',
+                caption: 'Сцена у панорамных окон'
+            },
+            {
+                src: 'https://images.unsplash.com/photo-1508214751196-bcfd4ca60f91?auto=format&fit=crop&w=900&q=80',
+                caption: 'Пластический дуэт в свете города'
+            }
+        ],
+        ticketUrl: 'https://iframeab-pre2514.intickets.ru/event/11756122/#abiframe'
+    },
+    ostrov: {
+        title: 'Остров',
+        venue: 'Санкт-Петербург · Лофт «Остров»',
+        image: 'https://images.unsplash.com/photo-1485563845929-11d0e5e56b1f?auto=format&fit=crop&w=1200&q=80',
+        description:
+            'Современная притча о поиске себя и необходимости одиночества, где звук, свет и пластика создают собственную вселенную.',
+        creators: [
+            { role: 'Режиссёр', name: 'Вера Анненкова' },
+            { role: 'Музыкальный продюсер', name: 'Михаил Маликов' },
+            { role: 'Исполнители', name: 'Алина Мазненкова, Максим Дементьев' },
+            { role: 'Художник по свету', name: 'Аксинья Олейник' }
+        ],
+        gallery: [
+            {
+                src: 'https://images.unsplash.com/photo-1500375592092-40eb2168fd21?auto=format&fit=crop&w=900&q=80',
+                caption: 'Герои на краю острова'
+            },
+            {
+                src: 'https://images.unsplash.com/photo-1462212210333-335063b676d3?auto=format&fit=crop&w=900&q=80',
+                caption: 'Мистическое пространство спектакля'
+            },
+            {
+                src: 'https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?auto=format&fit=crop&w=900&q=80',
+                caption: 'Музыкальный эпизод у моря'
+            }
+        ],
+        ticketUrl: 'https://iframeab-pre2514.intickets.ru/events/#abiframe'
+    }
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    const heroSlider = setupHeroSlider();
+    const modalController = setupAfishaModal();
+    initAfishaSection(modalController, heroSlider);
+});
+
+function setupHeroSlider() {
+    const slider = document.querySelector('.hero-slider');
+    if (!slider) {
+        return { update() {} };
+    }
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const cycleDuration = 5000;
+    let slides = [];
+    let currentIndex = 0;
+    let timerId = null;
+
+    function refreshSlides() {
+        slides = Array.from(slider.querySelectorAll('.banner-item'));
+
+        if (!slides.length) {
+            stop();
+            return;
+        }
+
+        if (!slides[currentIndex]) {
+            currentIndex = 0;
+        }
+
+        slides.forEach((slide, index) => {
+            slide.classList.toggle('is-active', index === currentIndex);
+        });
+
+        if (reduceMotion || slides.length <= 1) {
+            stop();
+        } else {
+            start();
+        }
+    }
+
+    function start() {
+        if (timerId || reduceMotion || slides.length <= 1) {
+            return;
+        }
+
+        timerId = window.setInterval(() => {
+            if (!slides.length) {
+                return;
+            }
+
+            slides[currentIndex]?.classList.remove('is-active');
+            currentIndex = (currentIndex + 1) % slides.length;
+            slides[currentIndex]?.classList.add('is-active');
+        }, cycleDuration);
+    }
+
+    function stop() {
+        if (timerId) {
+            window.clearInterval(timerId);
+            timerId = null;
+        }
+    }
+
+    function update(eventList = []) {
+        const dynamicSlides = slider.querySelectorAll('[data-hero-dynamic]');
+        dynamicSlides.forEach((slide) => slide.remove());
+
+        if (Array.isArray(eventList) && eventList.length) {
+            const sorted = [...eventList].sort((a, b) => {
+                const aTime = a.date instanceof Date && !Number.isNaN(a.date.getTime()) ? a.date.getTime() : Number.MAX_SAFE_INTEGER;
+                const bTime = b.date instanceof Date && !Number.isNaN(b.date.getTime()) ? b.date.getTime() : Number.MAX_SAFE_INTEGER;
+
+                if (aTime === bTime) {
+                    return (a.title || '').localeCompare(b.title || '', 'ru');
+                }
+
+                return aTime - bTime;
+            });
+
+            const fragment = document.createDocumentFragment();
+
+            sorted.slice(0, 3).forEach((event) => {
+                if (!event || !event.title) {
+                    return;
+                }
+
+                const slide = document.createElement('div');
+                slide.className = 'banner-item';
+                slide.setAttribute('data-hero-dynamic', '');
+
+                if (event.image) {
+                    slide.style.setProperty('--slide-bg', `url('${escapeCssUrl(event.image)}')`);
+                }
+
+                const dateEl = document.createElement('div');
+                dateEl.className = 'banner-date';
+                dateEl.textContent = formatHeroDate(event.date, event.time);
+                slide.appendChild(dateEl);
+
+                const titleEl = document.createElement('div');
+                titleEl.className = 'banner-title';
+                titleEl.textContent = event.title;
+                slide.appendChild(titleEl);
+
+                if (event.ticketUrl) {
+                    const link = document.createElement('a');
+                    link.className = 'banner-cta';
+                    link.href = event.ticketUrl;
+                    link.target = '_blank';
+                    link.rel = 'noopener';
+                    link.textContent = 'Купить билет';
+                    slide.appendChild(link);
+                } else {
+                    const soon = document.createElement('span');
+                    soon.className = 'banner-cta banner-cta--disabled';
+                    soon.textContent = 'Скоро в продаже';
+                    slide.appendChild(soon);
+                }
+
+                fragment.appendChild(slide);
+            });
+
+            slider.appendChild(fragment);
+        }
+
+        stop();
+        const brandSlide = slider.querySelector('[data-hero-brand]');
+        currentIndex = brandSlide ? Array.from(slider.children).indexOf(brandSlide) : 0;
+        if (currentIndex < 0) {
+            currentIndex = 0;
+        }
+
+        refreshSlides();
+    }
+
+    refreshSlides();
+
+    return {
+        update
+    };
+}
+
+function setupAfishaModal() {
+    const modal = document.querySelector('[data-afisha-modal]');
+    if (!modal) {
+        return { open() {}, close() {} };
+    }
+
+    const dialog = modal.querySelector('[data-afisha-modal-dialog]');
+    const titleEl = modal.querySelector('[data-afisha-modal-title]');
+    const metaEl = modal.querySelector('[data-afisha-modal-meta]');
+    const descEl = modal.querySelector('[data-afisha-modal-description]');
+    const creatorsEl = modal.querySelector('[data-afisha-modal-creators]');
+    const galleryEl = modal.querySelector('[data-afisha-modal-gallery]');
+    const ticketEl = modal.querySelector('[data-afisha-modal-ticket]');
+    const closeTriggers = modal.querySelectorAll('[data-afisha-modal-close]');
+    let restoreFocusTo = null;
+
+    closeTriggers.forEach((trigger) => {
+        trigger.addEventListener('click', close);
+    });
+
+    modal.addEventListener('click', (event) => {
+        if (event.target === modal) {
+            close();
+        }
+    });
+
+    function open(details) {
+        if (!details) {
+            return;
+        }
+
+        restoreFocusTo = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+        const title = details.title || 'Спектакль';
+        if (titleEl) {
+            titleEl.textContent = title;
+        }
+
+        if (metaEl) {
+            metaEl.textContent = details.modalMeta || '';
+            metaEl.hidden = !metaEl.textContent;
+        }
+
+        if (descEl) {
+            descEl.textContent = details.description || '';
+            descEl.hidden = !descEl.textContent;
+        }
+
+        renderCreators(details.creators || []);
+        renderGallery(details.gallery || [], title);
+
+        if (ticketEl) {
+            if (details.ticketUrl) {
+                ticketEl.href = details.ticketUrl;
+                ticketEl.hidden = false;
+            } else {
+                ticketEl.hidden = true;
+            }
+        }
+
+        modal.hidden = false;
+
+        requestAnimationFrame(() => {
+            modal.classList.add('is-visible');
+            const focusTarget = closeTriggers[0] || dialog;
+            if (focusTarget && typeof focusTarget.focus === 'function') {
+                focusTarget.focus();
+            }
+        });
+
+        document.addEventListener('keydown', handleKeyDown);
+    }
+
+    function close() {
+        modal.classList.remove('is-visible');
+        modal.addEventListener(
+            'transitionend',
+            () => {
+                modal.hidden = true;
+                document.removeEventListener('keydown', handleKeyDown);
+                if (restoreFocusTo && typeof restoreFocusTo.focus === 'function') {
+                    restoreFocusTo.focus();
+                }
+            },
+            { once: true }
+        );
+    }
+
+    function handleKeyDown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            close();
+        }
+    }
+
+    function renderCreators(list) {
+        if (!creatorsEl) {
+            return;
+        }
+
+        if (!list.length) {
+            creatorsEl.innerHTML = '';
+            creatorsEl.hidden = true;
+            return;
+        }
+
+        const markup = list
+            .map((item) => {
+                const role = escapeHtml(item?.role || '');
+                const name = escapeHtml(item?.name || '');
+                return `<li><span class="afisha-modal-role">${role}</span><span class="afisha-modal-name">${name}</span></li>`;
+            })
+            .join('');
+
+        creatorsEl.innerHTML = markup;
+        creatorsEl.hidden = false;
+    }
+
+    function renderGallery(images, title) {
+        if (!galleryEl) {
+            return;
+        }
+
+        if (!images.length) {
+            galleryEl.innerHTML = '';
+            galleryEl.hidden = true;
+            return;
+        }
+
+        const markup = images
+            .map((entry, index) => {
+                const src = typeof entry === 'string' ? entry : entry?.src;
+                if (!src) {
+                    return '';
+                }
+                const caption = typeof entry === 'object' && entry?.caption ? entry.caption : `Кадр ${index + 1}`;
+                const safeSrc = escapeAttr(src);
+                const safeCaption = escapeHtml(caption);
+                const altText = escapeAttr(`${title} — фотография ${index + 1}`);
+                return `<figure><img src="${safeSrc}" alt="${altText}" loading="lazy"><figcaption>${safeCaption}</figcaption></figure>`;
+            })
+            .filter(Boolean)
+            .join('');
+
+        galleryEl.innerHTML = markup;
+        galleryEl.hidden = !markup;
+    }
+
+    return { open, close };
+}
+
+function initAfishaSection(modalController, heroSlider) {
+    const section = document.querySelector('[data-afisha]');
+    if (!section) {
+        return;
+    }
+
+    const grid = section.querySelector('[data-afisha-grid]');
+    const empty = section.querySelector('[data-afisha-empty]');
+    const searchField = section.querySelector('[data-afisha-search]');
+    const sortField = section.querySelector('[data-afisha-sort]');
+    const statusField = section.querySelector('[data-afisha-status]');
+    const afishaLookup = new Map();
+    let events = [];
+
+    if (grid) {
+        renderAfishaSkeleton(grid, 3);
+        grid.addEventListener('click', (event) => {
+            const trigger = event.target.closest('[data-afisha-trigger]');
+            if (!trigger) {
+                return;
+            }
+            const eventId = trigger.getAttribute('data-afisha-trigger');
+            if (!eventId) {
+                return;
+            }
+
+            const details = afishaLookup.get(eventId);
+            if (details && modalController && typeof modalController.open === 'function') {
+                modalController.open(details);
+            }
+        });
+    }
+
+    if (searchField) {
+        searchField.addEventListener('input', () => renderAfisha());
+    }
+
+    if (sortField) {
+        sortField.addEventListener('change', () => renderAfisha());
+    }
+
+    fetchAfishaEvents();
+
+    async function fetchAfishaEvents() {
+        if (!grid) {
+            return;
+        }
+
+        grid.setAttribute('aria-busy', 'true');
+
+        try {
+            const response = await fetch(BAZA_AFISHA_URL, { cache: 'no-store' });
+            if (!response.ok) {
+                throw new Error(`Request failed: ${response.status}`);
+            }
+
+            const payload = await response.json();
+            const list = Array.isArray(payload?.events) ? payload.events : Array.isArray(payload) ? payload : [];
+            events = list.map(normalizeAfishaEvent).filter(Boolean);
+
+            afishaLookup.clear();
+            events.forEach((item) => {
+                if (item?.id) {
+                    afishaLookup.set(item.id, item);
+                }
+            });
+
+            if (statusField) {
+                statusField.hidden = true;
+                statusField.textContent = '';
+            }
+
+            if (heroSlider && typeof heroSlider.update === 'function') {
+                heroSlider.update(events);
+            }
+        } catch (error) {
+            console.error('Не удалось загрузить baza_afisha.json', error);
+            events = [];
+            afishaLookup.clear();
+
+            if (statusField) {
+                statusField.hidden = false;
+                statusField.textContent = 'Не удалось загрузить baza_afisha.json. Проверьте содержимое файла.';
+            }
+
+            if (heroSlider && typeof heroSlider.update === 'function') {
+                heroSlider.update([]);
+            }
+        }
+
+        renderAfisha();
+    }
+
+    function renderAfisha() {
+        if (!grid) {
+            return;
+        }
+
+        const term = (searchField?.value || '').trim().toLowerCase();
+        const sortValue = sortField?.value || 'date_asc';
+
+        const filtered = events.filter((event) => {
+            const haystack = `${event.title || ''} ${event.venue || ''}`.toLowerCase();
+            return haystack.includes(term);
+        });
+
+        filtered.sort((a, b) => {
+            const aTime = a.date ? a.date.getTime() : 0;
+            const bTime = b.date ? b.date.getTime() : 0;
+            return sortValue === 'date_desc' ? bTime - aTime : aTime - bTime;
+        });
+
+        grid.innerHTML = filtered.map(renderAfishaCard).join('');
+        grid.setAttribute('aria-busy', 'false');
+
+        if (empty) {
+            if (filtered.length) {
+                empty.hidden = true;
+            } else {
+                empty.hidden = false;
+                empty.textContent = term
+                    ? 'По вашему запросу ничего не найдено.'
+                    : 'События не найдены. Добавьте спектакли в baza_afisha.json.';
+            }
+        }
+    }
+}
+
+function normalizeAfishaEvent(raw) {
+    if (!raw) {
+        return null;
+    }
+
+    const id = raw.id || slugify(raw.title || '');
+    const supplemental = AFISHA_SUPPLEMENTAL[id] || {};
+    const title = raw.title || supplemental.title || 'Без названия';
+    const time = raw.time || '';
+    const venue = raw.venue || supplemental.venue || '';
+    const isoDate = buildIsoDate(raw.date, time);
+    const parsedDate = isoDate ? new Date(isoDate) : null;
+    const isValidDate = parsedDate instanceof Date && !Number.isNaN(parsedDate?.getTime());
+    const cardMeta = buildCardMeta(parsedDate, time, venue);
+    const modalMeta = buildModalMeta(parsedDate, time, venue);
+    const description = supplemental.description || '';
+    const creators = Array.isArray(supplemental.creators) ? supplemental.creators : [];
+    const gallery = Array.isArray(supplemental.gallery) ? supplemental.gallery : [];
+    const image = supplemental.image || AFISHA_PLACEHOLDER_IMAGE;
+    const ticketUrl = raw.link || supplemental.ticketUrl || '';
+
+    return {
+        id: id || slugify(title),
+        title,
+        date: isValidDate ? parsedDate : null,
+        time,
+        cardMeta,
+        modalMeta,
+        description,
+        creators,
+        gallery,
+        image,
+        ticketUrl,
+        venue
+    };
+}
+
+function buildIsoDate(date, time) {
+    if (!date) {
+        return null;
+    }
+
+    const normalizedDate = `${date}`.trim();
+    if (!time) {
+        return normalizedDate;
+    }
+
+    const normalizedTime = `${time}`.trim();
+    return `${normalizedDate}T${normalizedTime}`;
+}
+
+function buildCardMeta(date, time, venue) {
+    const parts = [];
+
+    if (date instanceof Date && !Number.isNaN(date.getTime())) {
+        parts.push(
+            date.toLocaleDateString('ru-RU', {
+                day: '2-digit',
+                month: 'long'
+            })
+        );
+    }
+
+    if (time) {
+        parts.push(time);
+    }
+
+    if (venue) {
+        parts.push(venue);
+    }
+
+    return parts.length ? parts.join(' · ') : 'Дата уточняется';
+}
+
+function buildModalMeta(date, time, venue) {
+    const parts = [];
+
+    if (date instanceof Date && !Number.isNaN(date.getTime())) {
+        parts.push(
+            date.toLocaleDateString('ru-RU', {
+                day: '2-digit',
+                month: 'long',
+                year: 'numeric'
+            })
+        );
+    }
+
+    if (time) {
+        parts.push(`Начало в ${time}`);
+    }
+
+    if (venue) {
+        parts.push(venue);
+    }
+
+    return parts.join(' · ');
+}
+
+function formatHeroDate(date, time) {
+    const parts = [];
+
+    if (date instanceof Date && !Number.isNaN(date.getTime())) {
+        parts.push(
+            date.toLocaleDateString('ru-RU', {
+                day: '2-digit',
+                month: 'long',
+                year: 'numeric'
+            })
+        );
+    }
+
+    if (time) {
+        parts.push(time);
+    }
+
+    return parts.join(' · ') || 'Дата уточняется';
+}
+
+function renderAfishaCard(event) {
+    const safeTitle = escapeHtml(event.title);
+    const safeAlt = escapeAttr(`Афиша спектакля ${event.title}`);
+    const cover = escapeAttr(event.image || AFISHA_PLACEHOLDER_IMAGE);
+    const meta = escapeHtml(event.cardMeta || 'Дата уточняется');
+    const hasTicket = Boolean(event.ticketUrl);
+    const ticketLink = hasTicket ? escapeAttr(event.ticketUrl) : '';
+    const triggerId = escapeAttr(event.id || 'event');
+    const openLabel = escapeAttr(`Открыть описание спектакля «${event.title}»`);
+    const actionMarkup = hasTicket
+        ? `<a class="btn" href="${ticketLink}" target="_blank" rel="noopener">Купить билет</a>`
+        : '<span class="afisha-card-badge" aria-label="Билеты появятся позже">Скоро в продаже</span>';
+
+    return `
+        <article class="afisha-card" data-afisha-id="${triggerId}">
+            <button type="button" class="afisha-card-cover" data-afisha-trigger="${triggerId}" aria-label="${openLabel}">
+                <img src="${cover}" alt="${safeAlt}" loading="lazy">
+            </button>
+            <div class="afisha-card-body">
+                <h3 class="afisha-card-title">${safeTitle}</h3>
+                <div class="afisha-card-meta">${meta}</div>
+                <div class="afisha-card-actions">
+                    ${actionMarkup}
+                </div>
+            </div>
+        </article>
+    `;
+}
+
+function renderAfishaSkeleton(grid, count) {
+    if (!grid) {
+        return;
+    }
+
+    const skeleton = `
+        <article class="afisha-card afisha-card--skeleton">
+            <div class="afisha-card-cover"></div>
+            <div class="afisha-card-body">
+                <h3 class="afisha-card-title">Загрузка…</h3>
+                <div class="afisha-card-meta">Расписание обновляется</div>
+                <div class="afisha-card-actions">
+                    <span class="btn">&nbsp;</span>
+                </div>
+            </div>
+        </article>
+    `;
+
+    grid.innerHTML = Array.from({ length: count }, () => skeleton).join('');
+}
+
+function slugify(value) {
+    return String(value || '')
+        .toLowerCase()
+        .replace(/ё/g, 'е')
+        .replace(/[^a-z0-9а-я]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+function escapeHtml(value) {
+    const map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+    };
+
+    return String(value ?? '').replace(/[&<>"']/g, (char) => map[char]);
+}
+
+function escapeAttr(value) {
+    return escapeHtml(value);
+}
+
+function escapeCssUrl(value) {
+    return String(value ?? '').replace(/([')\\"])/g, '\\$1');
+}


### PR DESCRIPTION
## Summary
- add venue metadata to `baza_afisha.json` so events carry their location details
- enforce single-line titles and aligned call-to-actions in the Afisha grid with a "Скоро в продаже" badge when no ticket link is present
- populate hero slides from the loaded schedule, reusing the same data for ticket buttons and upcoming dates

## Testing
- node --check main.js
- python -m json.tool baza_afisha.json

------
https://chatgpt.com/codex/tasks/task_e_68d0230de92c8322b23249558a188df3