### PR TITLE
Fix upload request options syntax

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -970,7 +970,7 @@
         formData.append('image', file);
 
         const response = await fetch(API_UPLOAD_URL, {
-            method: 'POST',e
+            method: 'POST',
             headers,
             body: formData,
         });


### PR DESCRIPTION
## Summary
- remove stray character in the fetch options of uploadImageFile so the admin bundle parses

## Testing
- node --check admin.js

------
https://chatgpt.com/codex/tasks/task_e_68d141f1f89c8322bef1a9785f1cf884