### PR TITLE
Remove merge marker from upload endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,7 +92,6 @@ app.post('/api/admin/events', requireAdminToken, async (req, res) => {
 });
 
 app.post('/api/admin/upload', requireAdminToken, upload.single('image'), (req, res) => {
-=======
     if (!req.file) {
         res.status(400).json({ error: 'Файл не получен.' });
         return;


### PR DESCRIPTION
## Summary
- remove a stray merge conflict marker from the admin upload route declaration so the handler is valid JavaScript again

## Testing
- ADMIN_TOKEN=testtoken npm start (manually terminated after verifying startup)
- curl -i -H 'Authorization: Bearer testtoken' -F image=@test.png http://localhost:3000/api/admin/upload

------
https://chatgpt.com/codex/tasks/task_e_68d1426b06448322bfe92ac83e752063