### PR TITLE
Set default admin access key to ammapro

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 ## Локальный запуск
 
 1. Установите зависимости: `npm install`.
-2. Задайте ключ администратора в переменной окружения `ADMIN_TOKEN` и запустите сервер:
+2. По умолчанию административные API используют ключ доступа `ammapro`. Чтобы задать свой ключ (например, для продакшена),
+   укажите его в переменной окружения `ADMIN_TOKEN` перед запуском сервера:
    - macOS/Linux: `ADMIN_TOKEN=supersecret npm start`
    - Windows (PowerShell): `$env:ADMIN_TOKEN='supersecret'; npm start`
    - Windows (cmd.exe): `set ADMIN_TOKEN=supersecret && npm start`

--- a/admin.js
+++ b/admin.js
@@ -6,6 +6,7 @@
     const API_UPLOAD_URL = '/api/admin/upload';
 
     const ADMIN_AUTH_STORAGE_KEY = 'amma-admin-token';
+    const DEFAULT_ADMIN_TOKEN = 'ammapro';
 
     const UNSAVED_MESSAGE = 'Есть несохранённые изменения';
     const UPLOAD_MESSAGE = 'Идёт загрузка файлов…';
@@ -100,8 +101,14 @@
     }
 
     function hydrateAuthToken() {
-        state.authToken = getStoredAuthToken();
-        updateAuthButton();
+        const storedToken = getStoredAuthToken();
+        if (storedToken) {
+            state.authToken = storedToken;
+            updateAuthButton();
+            return;
+        }
+
+        setAuthToken(DEFAULT_ADMIN_TOKEN);
     }
 
     async function loadInitialData() {

--- a/server.js
+++ b/server.js
@@ -12,10 +12,12 @@ const ROOT_DIR = __dirname;
 const DATA_FILE = path.join(ROOT_DIR, 'baza_afisha.json');
 const UPLOADS_DIR = path.join(ROOT_DIR, 'uploads');
 const MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // 5 MB
-const ADMIN_TOKEN = typeof process.env.ADMIN_TOKEN === 'string' ? process.env.ADMIN_TOKEN.trim() : '';
+const DEFAULT_ADMIN_TOKEN = 'ammapro';
+const ENV_ADMIN_TOKEN = typeof process.env.ADMIN_TOKEN === 'string' ? process.env.ADMIN_TOKEN.trim() : '';
+const ADMIN_TOKEN = ENV_ADMIN_TOKEN || DEFAULT_ADMIN_TOKEN;
 
-if (!ADMIN_TOKEN) {
-    console.warn('Административные API защищены и выключены: задайте переменную окружения ADMIN_TOKEN, чтобы включить сохранение.');
+if (!ENV_ADMIN_TOKEN) {
+    console.warn('Используется ключ доступа администратора по умолчанию. Задайте переменную окружения ADMIN_TOKEN, чтобы его изменить.');
 }
 
 


### PR DESCRIPTION
## Summary
- default the administrative token to `ammapro` on the server while still allowing overrides via `ADMIN_TOKEN`
- make the admin panel preload the default token into local storage
- document the new default key in the README

## Testing
- node --check server.js
- node --check admin.js

------
https://chatgpt.com/codex/tasks/task_e_68d149f25e908322855e79d1318409f9