### PR TITLE
Add ticket widget, sync modal actions, and enhance gallery admin

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -7,6 +7,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="//s3.intickets.ru/intickets.min.css">
+    <script src="//s3.intickets.ru/intickets.js"></script>
     <style>
         :root {
             color-scheme: dark;
@@ -348,6 +350,70 @@
             accent-color: var(--accent);
         }
 
+        .admin-field--gallery {
+            padding: 1rem;
+            border-radius: 14px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(0, 0, 0, 0.35);
+            display: grid;
+            gap: 1rem;
+        }
+
+        .admin-gallery {
+            display: grid;
+            gap: 1rem;
+        }
+
+        .admin-gallery-empty {
+            margin: 0;
+            padding: 1rem;
+            border-radius: 12px;
+            border: 1px dashed rgba(255, 255, 255, 0.15);
+            text-align: center;
+            color: var(--muted);
+        }
+
+        .admin-gallery-item {
+            display: grid;
+            grid-template-columns: 160px 1fr;
+            gap: 1rem;
+            align-items: stretch;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 14px;
+            padding: 1rem;
+            background: rgba(0, 0, 0, 0.35);
+        }
+
+        .admin-gallery-thumb {
+            width: 100%;
+            aspect-ratio: 4 / 3;
+            border-radius: 12px;
+            background-size: cover;
+            background-position: center;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+        }
+
+        .admin-gallery-fields {
+            display: grid;
+            gap: 0.75rem;
+        }
+
+        .admin-gallery-field {
+            display: grid;
+            gap: 0.35rem;
+        }
+
+        .admin-gallery-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+        }
+
+        .admin-gallery-item-actions {
+            display: flex;
+            justify-content: flex-end;
+        }
+
         .admin-event__actions {
             display: flex;
             flex-wrap: wrap;
@@ -418,6 +484,14 @@
             .admin-event__summary {
                 flex-direction: column;
                 align-items: flex-start;
+            }
+
+            .admin-gallery-item {
+                grid-template-columns: 1fr;
+            }
+
+            .admin-gallery-thumb {
+                aspect-ratio: 3 / 2;
             }
 
             .admin-hero-item {

--- a/afisha.html
+++ b/afisha.html
@@ -7,6 +7,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;700&family=Manrope:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="//s3.intickets.ru/intickets.min.css">
+    <script src="//s3.intickets.ru/intickets.js"></script>
     <link rel="stylesheet" href="afisha.css">
 </head>
 <body>

--- a/baza_afisha (1).json
+++ b/baza_afisha (1).json
@@ -9,6 +9,20 @@
       "link": "",
       "image": "https://amma-production.ru/img/maxresdefault.png",
       "description": "Легендарная история о дружбе и любви на фоне блокадного города.",
+      "gallery": [
+        {
+          "src": "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80",
+          "caption": "Погружение в атмосферу блокадного города"
+        },
+        {
+          "src": "https://images.unsplash.com/photo-1515169067865-5387ec356754?auto=format&fit=crop&w=900&q=80",
+          "caption": "Диалог героев на тёмной сцене"
+        },
+        {
+          "src": "https://images.unsplash.com/photo-1478720568477-152d9b164e26?auto=format&fit=crop&w=900&q=80",
+          "caption": "Финальный световой акцент спектакля"
+        }
+      ],
       "showInHero": true,
       "heroOrder": 1
     },
@@ -21,6 +35,20 @@
       "link": "",
       "image": "https://amma-production.ru/img/OS_04401.jpg",
       "description": "Поэтический спектакль о городских историях и ритме мегаполиса.",
+      "gallery": [
+        {
+          "src": "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80",
+          "caption": "Городской ритм спектакля"
+        },
+        {
+          "src": "https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80",
+          "caption": "Сцена у панорамных окон"
+        },
+        {
+          "src": "https://images.unsplash.com/photo-1508214751196-bcfd4ca60f91?auto=format&fit=crop&w=900&q=80",
+          "caption": "Пластический дуэт в свете города"
+        }
+      ],
       "showInHero": true,
       "heroOrder": 2
     }

--- a/baza_afisha.json
+++ b/baza_afisha.json
@@ -9,6 +9,20 @@
       "link": "",
       "image": "https://amma-production.ru/img/maxresdefault.png",
       "description": "Легендарная история о дружбе и любви на фоне блокадного города.",
+      "gallery": [
+        {
+          "src": "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80",
+          "caption": "Погружение в атмосферу блокадного города"
+        },
+        {
+          "src": "https://images.unsplash.com/photo-1515169067865-5387ec356754?auto=format&fit=crop&w=900&q=80",
+          "caption": "Диалог героев на тёмной сцене"
+        },
+        {
+          "src": "https://images.unsplash.com/photo-1478720568477-152d9b164e26?auto=format&fit=crop&w=900&q=80",
+          "caption": "Финальный световой акцент спектакля"
+        }
+      ],
       "showInHero": true,
       "heroOrder": 1
     },
@@ -21,6 +35,20 @@
       "link": "https://iframeab-pre2514.intickets.ru/seance/60835614/#abiframe",
       "image": "https://amma-production.ru/img/OS_04401.jpg",
       "description": "Ироничная комедия",
+      "gallery": [
+        {
+          "src": "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80",
+          "caption": "Городской ритм спектакля"
+        },
+        {
+          "src": "https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80",
+          "caption": "Сцена у панорамных окон"
+        },
+        {
+          "src": "https://images.unsplash.com/photo-1508214751196-bcfd4ca60f91?auto=format&fit=crop&w=900&q=80",
+          "caption": "Пластический дуэт в свете города"
+        }
+      ],
       "showInHero": true,
       "heroOrder": 2
     }

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;700&family=Montserrat:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="//s3.intickets.ru/intickets.min.css">
+    <script src="//s3.intickets.ru/intickets.js"></script>
     <style>
         :root {
             --background: #0f0f0f;
@@ -504,20 +506,20 @@
 
         .afisha-card-actions {
             margin-top: auto;
-            display: flex;
-            align-items: stretch;
+            display: grid;
+            gap: 0.75rem;
         }
 
         .afisha-card-actions > * {
-            flex: 1;
-            min-height: 3rem;
+            width: 100%;
         }
 
         .afisha-card-actions .btn {
             width: 100%;
         }
 
-        .afisha-card-badge {
+        .afisha-card-badge,
+        .afisha-modal-badge {
             display: inline-flex;
             align-items: center;
             justify-content: center;
@@ -531,6 +533,21 @@
             letter-spacing: 0.08em;
             font-weight: 600;
             white-space: nowrap;
+        }
+
+        .afisha-modal-actions {
+            margin-top: 1.75rem;
+            display: grid;
+            gap: 0.85rem;
+        }
+
+        .afisha-modal-actions .btn {
+            width: 100%;
+            justify-content: center;
+        }
+
+        .afisha-modal-badge {
+            width: 100%;
         }
         .afisha-empty {
             padding: 1.6rem;
@@ -1031,7 +1048,7 @@
                 <p class="afisha-modal-description" data-afisha-modal-description></p>
                 <ul class="afisha-modal-creators" data-afisha-modal-creators></ul>
                 <div class="afisha-modal-gallery" data-afisha-modal-gallery></div>
-                <a class="btn" data-afisha-modal-ticket target="_blank" rel="noopener">Купить билет</a>
+                <div class="afisha-modal-actions" data-afisha-modal-actions></div>
             </div>
         </div>
 

--- a/server.js
+++ b/server.js
@@ -143,6 +143,7 @@ function sanitizeEvent(rawEvent, index) {
         description: typeof rawEvent?.description === 'string' ? rawEvent.description.trim() : '',
         showInHero: Boolean(rawEvent?.showInHero ?? true),
         heroOrder,
+        gallery: sanitizeGallery(rawEvent?.gallery),
     };
 }
 
@@ -186,6 +187,37 @@ function sanitizeHeroOrder(value) {
 
     const number = Number(value);
     return Number.isFinite(number) ? number : null;
+}
+
+function sanitizeGallery(value) {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value
+        .map((entry) => {
+            if (!entry) {
+                return null;
+            }
+
+            if (typeof entry === 'string') {
+                const src = entry.trim();
+                return src ? { src } : null;
+            }
+
+            if (typeof entry === 'object') {
+                const src = typeof entry.src === 'string' ? entry.src.trim() : '';
+                if (!src) {
+                    return null;
+                }
+
+                const caption = typeof entry.caption === 'string' ? entry.caption.trim() : '';
+                return caption ? { src, caption } : { src };
+            }
+
+            return null;
+        })
+        .filter(Boolean);
 }
 
 function ensureUniqueIds(events) {


### PR DESCRIPTION
## Summary
- embed the Intickets widget assets in the public and admin pages so the ticket iframe can load everywhere
- align the playbill modal buttons with the grid cards by reusing ticket button data and handling multiple links
- extend the admin panel, API, and sample data to edit and persist gallery images for the modal description

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d18213a6988322b2f13cfb4d59cd88